### PR TITLE
Feature/classlist upload error handling

### DIFF
--- a/packages/portal/backend/src/server/common/CSVParser.ts
+++ b/packages/portal/backend/src/server/common/CSVParser.ts
@@ -89,7 +89,7 @@ export class CSVParser {
         });
         columns.forEach((column) => {
             if (missingData[column].length) {
-                throw new Error('Missing necessary field data in class list ' + JSON.stringify(missingData));
+                throw new Error('CWL, SNUM, and ACCT fields cannot be empty: ' + JSON.stringify(missingData));
             }
         });
     }

--- a/packages/portal/backend/src/server/common/CSVParser.ts
+++ b/packages/portal/backend/src/server/common/CSVParser.ts
@@ -201,9 +201,9 @@ export class CSVParser {
         });
         columns.forEach((column) => {
             if (missingData[column].length) {
-                Log.error('CSVParser::missingDataCheck(..) - ERROR: CWL, SNUM, and ACCT fields cannot be empty: '
+                Log.error('CSVParser::missingDataCheck(..) - ERROR: Certain fields cannot be empty: '
                     + JSON.stringify(missingData));
-                throw new Error('CWL, SNUM, and ACCT fields cannot be empty: ' + JSON.stringify(missingData));
+                throw new Error('Certain fields cannot be empty: ' + JSON.stringify(missingData));
             }
         });
     }

--- a/packages/portal/backend/src/server/common/CSVParser.ts
+++ b/packages/portal/backend/src/server/common/CSVParser.ts
@@ -105,7 +105,6 @@ export class CSVParser {
             this.missingDataCheck(data, ['SNUM', 'ACCT', 'CWL']);
             for (const row of data) {
                 // Log.trace(JSON.stringify(row));
-
                 if (typeof row.ACCT !== 'undefined' && typeof row.CWL !== 'undefined' &&
                     typeof row.SNUM !== 'undefined' && typeof row.FIRST !== 'undefined' &&
                     typeof row.LAST !== 'undefined' && typeof row.LAB !== 'undefined') {

--- a/packages/portal/backend/src/server/common/CSVParser.ts
+++ b/packages/portal/backend/src/server/common/CSVParser.ts
@@ -54,8 +54,8 @@ export class CSVParser {
             const data = await this.parsePath(path);
             const pc = new PersonController();
             const peoplePromises: Array<Promise<Person>> = [];
-            this.duplicateDataCheck(data, ['SNUM', 'ACCT', 'CWL']);
-            this.missingDataCheck(data, ['SNUM', 'ACCT', 'CWL']);
+            this.duplicateDataCheck(data, ['ACCT', 'CWL']);
+            this.missingDataCheck(data, ['ACCT', 'CWL']);
             for (const row of data) {
                 // Log.trace(JSON.stringify(row));
                 if (typeof row.ACCT !== 'undefined' && typeof row.CWL !== 'undefined' &&

--- a/packages/portal/backend/src/server/common/CSVParser.ts
+++ b/packages/portal/backend/src/server/common/CSVParser.ts
@@ -47,7 +47,7 @@ export class CSVParser {
         });
     }
 
-    private duplicateDataCheck(data: any[], columnNames: string[]): any {
+    private duplicateDataCheck(data: any[], columnNames: string[]) {
         Log.info('CSVParser::duplicateDataCheck -- start');
         const that = this;
         const dupColumnData: any = {};
@@ -65,10 +65,10 @@ export class CSVParser {
         Log.info('CSVParser::getDuplicateRowsByColumn -- start');
         const set = new Set();
         return data.filter((row) => {
-            if (set.has(row[column])) {
+            if (set.has(row[column].toLowerCase())) {
                 return true;
             }
-            set.add(row[column]);
+            set.add(row[column].toLowerCase());
             return false;
         });
     }
@@ -80,7 +80,7 @@ export class CSVParser {
             const data = await this.parsePath(path);
             const pc = new PersonController();
             const peoplePromises: Array<Promise<Person>> = [];
-            const duplicateData: any[] = this.duplicateDataCheck(data, ['SNUM', 'ACCT', 'CWL']);
+            this.duplicateDataCheck(data, ['SNUM', 'ACCT', 'CWL']);
             for (const row of data) {
                 // Log.trace(JSON.stringify(row));
 

--- a/packages/portal/backend/src/server/common/CSVParser.ts
+++ b/packages/portal/backend/src/server/common/CSVParser.ts
@@ -61,7 +61,7 @@ export class CSVParser {
         });
     }
 
-    private getDuplicateRowsByColumn(data: any[], column: string) {
+    private getDuplicateRowsByColumn(data: any[], column: string): any[] {
         Log.info('CSVParser::getDuplicateRowsByColumn -- start');
         const set = new Set();
         return data.filter((row) => {
@@ -73,6 +73,27 @@ export class CSVParser {
         });
     }
 
+    private getMissingDataRowsByColumn(data: any[], column: string): any[] {
+        return data.filter((row) => {
+            if (row[column] === '') {
+                return true;
+            }
+            return false;
+        });
+    }
+    private missingDataCheck(data: any[], columns: string[]) {
+        const that = this;
+        const missingData: any = {};
+        columns.forEach((column) => {
+            Object.assign(missingData, {[column]: that.getMissingDataRowsByColumn(data, column)});
+        });
+        columns.forEach((column) => {
+            if (missingData[column].length) {
+                throw new Error('Missing necessary field data in class list ' + JSON.stringify(missingData));
+            }
+        });
+    }
+
     public async processClasslist(personId: string, path: string): Promise<Person[]> {
         try {
             Log.info('CSVParser::processClasslist(..) - start');
@@ -81,6 +102,7 @@ export class CSVParser {
             const pc = new PersonController();
             const peoplePromises: Array<Promise<Person>> = [];
             this.duplicateDataCheck(data, ['SNUM', 'ACCT', 'CWL']);
+            this.missingDataCheck(data, ['SNUM', 'ACCT', 'CWL']);
             for (const row of data) {
                 // Log.trace(JSON.stringify(row));
 

--- a/packages/portal/backend/src/server/common/CSVParser.ts
+++ b/packages/portal/backend/src/server/common/CSVParser.ts
@@ -47,53 +47,6 @@ export class CSVParser {
         });
     }
 
-    private duplicateDataCheck(data: any[], columnNames: string[]) {
-        Log.info('CSVParser::duplicateDataCheck -- start');
-        const that = this;
-        const dupColumnData: any = {};
-        columnNames.forEach(function(column) {
-            Object.assign(dupColumnData, {[column]: that.getDuplicateRowsByColumn(data, column)});
-        });
-        columnNames.forEach(function(column) {
-            if (dupColumnData[column].length) {
-                throw new Error('Duplicate Data Check Error: ' + JSON.stringify(dupColumnData));
-            }
-        });
-    }
-
-    private getDuplicateRowsByColumn(data: any[], column: string): any[] {
-        Log.info('CSVParser::getDuplicateRowsByColumn -- start');
-        const set = new Set();
-        return data.filter((row) => {
-            if (set.has(row[column].toLowerCase())) {
-                return true;
-            }
-            set.add(row[column].toLowerCase());
-            return false;
-        });
-    }
-
-    private getMissingDataRowsByColumn(data: any[], column: string): any[] {
-        return data.filter((row) => {
-            if (row[column] === '') {
-                return true;
-            }
-            return false;
-        });
-    }
-    private missingDataCheck(data: any[], columns: string[]) {
-        const that = this;
-        const missingData: any = {};
-        columns.forEach((column) => {
-            Object.assign(missingData, {[column]: that.getMissingDataRowsByColumn(data, column)});
-        });
-        columns.forEach((column) => {
-            if (missingData[column].length) {
-                throw new Error('CWL, SNUM, and ACCT fields cannot be empty: ' + JSON.stringify(missingData));
-            }
-        });
-    }
-
     public async processClasslist(personId: string, path: string): Promise<Person[]> {
         try {
             Log.info('CSVParser::processClasslist(..) - start');
@@ -202,4 +155,52 @@ export class CSVParser {
         }
     }
 
+    private duplicateDataCheck(data: any[], columnNames: string[]) {
+        Log.info('CSVParser::duplicateDataCheck -- start');
+        const that = this;
+        const dupColumnData: any = {};
+        columnNames.forEach(function(column) {
+            Object.assign(dupColumnData, {[column]: that.getDuplicateRowsByColumn(data, column)});
+        });
+        columnNames.forEach(function(column) {
+            if (dupColumnData[column].length) {
+                throw new Error('Duplicate Data Check Error: ' + JSON.stringify(dupColumnData));
+            }
+        });
+    }
+
+    private getDuplicateRowsByColumn(data: any[], column: string): any[] {
+        Log.info('CSVParser::getDuplicateRowsByColumn -- start');
+        const set = new Set();
+        return data.filter((row) => {
+            if (set.has(row[column].toLowerCase())) {
+                return true;
+            }
+            set.add(row[column].toLowerCase());
+            return false;
+        });
+    }
+
+    private getMissingDataRowsByColumn(data: any[], column: string): any[] {
+        Log.info('CSVParser::getMissingDataRowsByColumn -- start');
+        return data.filter((row) => {
+            if (row[column] === '') {
+                return true;
+            }
+            return false;
+        });
+    }
+    private missingDataCheck(data: any[], columns: string[]) {
+        Log.info('CSVParser::missingDataCheck -- start');
+        const that = this;
+        const missingData: any = {};
+        columns.forEach((column) => {
+            Object.assign(missingData, {[column]: that.getMissingDataRowsByColumn(data, column)});
+        });
+        columns.forEach((column) => {
+            if (missingData[column].length) {
+                throw new Error('CWL, SNUM, and ACCT fields cannot be empty: ' + JSON.stringify(missingData));
+            }
+        });
+    }
 }

--- a/packages/portal/backend/src/server/common/CSVParser.ts
+++ b/packages/portal/backend/src/server/common/CSVParser.ts
@@ -156,7 +156,7 @@ export class CSVParser {
     }
 
     private duplicateDataCheck(data: any[], columnNames: string[]) {
-        Log.info('CSVParser::duplicateDataCheck -- start');
+        Log.trace('CSVParser::duplicateDataCheck -- start');
         const that = this;
         const dupColumnData: any = {};
         columnNames.forEach(function(column) {
@@ -164,13 +164,15 @@ export class CSVParser {
         });
         columnNames.forEach(function(column) {
             if (dupColumnData[column].length) {
+                Log.error('CSVParser::duplicateDataCheck(..) - ERROR: Duplicate Data Check Error'
+                    + JSON.stringify(dupColumnData));
                 throw new Error('Duplicate Data Check Error: ' + JSON.stringify(dupColumnData));
             }
         });
     }
 
     private getDuplicateRowsByColumn(data: any[], column: string): any[] {
-        Log.info('CSVParser::getDuplicateRowsByColumn -- start');
+        Log.trace('CSVParser::getDuplicateRowsByColumn -- start');
         const set = new Set();
         return data.filter((row) => {
             if (set.has(row[column].toLowerCase())) {
@@ -182,7 +184,7 @@ export class CSVParser {
     }
 
     private getMissingDataRowsByColumn(data: any[], column: string): any[] {
-        Log.info('CSVParser::getMissingDataRowsByColumn -- start');
+        Log.trace('CSVParser::getMissingDataRowsByColumn -- start');
         return data.filter((row) => {
             if (row[column] === '') {
                 return true;
@@ -191,7 +193,7 @@ export class CSVParser {
         });
     }
     private missingDataCheck(data: any[], columns: string[]) {
-        Log.info('CSVParser::missingDataCheck -- start');
+        Log.trace('CSVParser::missingDataCheck -- start');
         const that = this;
         const missingData: any = {};
         columns.forEach((column) => {
@@ -199,6 +201,8 @@ export class CSVParser {
         });
         columns.forEach((column) => {
             if (missingData[column].length) {
+                Log.error('CSVParser::missingDataCheck(..) - ERROR: CWL, SNUM, and ACCT fields cannot be empty: '
+                    + JSON.stringify(missingData));
                 throw new Error('CWL, SNUM, and ACCT fields cannot be empty: ' + JSON.stringify(missingData));
             }
         });

--- a/packages/portal/backend/test/CSVParserSpec.ts
+++ b/packages/portal/backend/test/CSVParserSpec.ts
@@ -31,6 +31,30 @@ describe('CSVParser', function() {
         expect(rows).to.have.lengthOf(5);
     });
 
+    it('Should reject a classlist with empty field from CWL, SNUM, ACCT fields', async function() {
+        const path = __dirname + '/data/classlistEmptyField.csv';
+        const csv = new CSVParser();
+        let ex = null;
+        try {
+            await csv.processClasslist(Test.ADMIN1.id, path);
+        } catch (err) {
+            ex = err;
+        }
+        expect(ex).to.not.be.null;
+    });
+
+    it('Should reject a classlist with duplicate data from CWL, SNUM, ACCT fields', async function() {
+        const path = __dirname + '/data/classlistDuplicateField.csv';
+        const csv = new CSVParser();
+        let ex = null;
+        try {
+            await csv.processClasslist(Test.ADMIN1.id, path);
+        } catch (err) {
+            ex = err;
+        }
+        expect(ex).to.not.be.null;
+    });
+
     it('Should be able to process an updated classlist', async function() {
         const path = __dirname + '/data/classlistValidUpdate.csv';
         const csv = new CSVParser();

--- a/packages/portal/backend/test/CSVParserSpec.ts
+++ b/packages/portal/backend/test/CSVParserSpec.ts
@@ -31,7 +31,7 @@ describe('CSVParser', function() {
         expect(rows).to.have.lengthOf(5);
     });
 
-    it('Should reject a classlist with empty field from CWL, SNUM, ACCT fields', async function() {
+    it('Should reject a classlist with empty field in fields: CWL, ACCT', async function() {
         const path = __dirname + '/data/classlistEmptyField.csv';
         const csv = new CSVParser();
         let ex = null;
@@ -43,7 +43,7 @@ describe('CSVParser', function() {
         expect(ex).to.not.be.null;
     });
 
-    it('Should reject a classlist with duplicate data from CWL, SNUM, ACCT fields', async function() {
+    it('Should reject a classlist with duplicate data in fields: CWL, ACCT', async function() {
         const path = __dirname + '/data/classlistDuplicateField.csv';
         const csv = new CSVParser();
         let ex = null;

--- a/packages/portal/backend/test/data/classlistDuplicateField.csv
+++ b/packages/portal/backend/test/data/classlistDuplicateField.csv
@@ -1,3 +1,3 @@
 ACCT,SNUM,CWL,LAST,FIRST,LAB
-x8x1,99992222,dkl23TEST,AasdfFirstTest,AasdfLastTest,L2C
-rthse2,99992222,rthse2new,Arthse2,Zrthse2Last,L2C
+x8x1,12347423,dkl23TEST,AasdfFirstTest,AasdfLastTest,L2C
+x8x1,99992222,rthse2new,Arthse2,Zrthse2Last,L2C

--- a/packages/portal/backend/test/data/classlistDuplicateField.csv
+++ b/packages/portal/backend/test/data/classlistDuplicateField.csv
@@ -1,0 +1,3 @@
+ACCT,SNUM,CWL,LAST,FIRST,LAB
+x8x1,99992222,dkl23TEST,AasdfFirstTest,AasdfLastTest,L2C
+rthse2,99992222,rthse2new,Arthse2,Zrthse2Last,L2C

--- a/packages/portal/backend/test/data/classlistEmptyField.csv
+++ b/packages/portal/backend/test/data/classlistEmptyField.csv
@@ -1,5 +1,5 @@
 ACCT,SNUM,CWL,LAST,FIRST,LAB
-a2b1,,aardvarkTEST,DadsfasFirstTest,DasdfLastTest,L2J
+a2b1,42383984,,DadsfasFirstTest,DasdfLastTest,L2J
 b6x4,48483222,badfasdTEST,CasdfFirstTest,CasdfLastTest,
 l2z2,29394944,e2klTEST,BasdfasFirstTest,BasdfLastTest,L2C
 x8x1,39292932,dkl23TEST,AasdfFirstTest,AasdfLastTest,L2C

--- a/packages/portal/backend/test/data/classlistEmptyField.csv
+++ b/packages/portal/backend/test/data/classlistEmptyField.csv
@@ -1,0 +1,6 @@
+ACCT,SNUM,CWL,LAST,FIRST,LAB
+a2b1,,aardvarkTEST,DadsfasFirstTest,DasdfLastTest,L2J
+b6x4,48483222,badfasdTEST,CasdfFirstTest,CasdfLastTest,
+l2z2,29394944,e2klTEST,BasdfasFirstTest,BasdfLastTest,L2C
+x8x1,39292932,dkl23TEST,AasdfFirstTest,AasdfLastTest,L2C
+rthse2,99992222,rthse2new,Arthse2,Zrthse2Last,L2C


### PR DESCRIPTION
https://github.com/ubccpsctech/classy/issues/3

@winstan 

Here is the pull-request for the errors that block the CSV import operation. There is another issue that manages the warnings that do not block the CSV import operation, but warn the user on the front-end.

General thoughts about this code:

- We might consider adding the Types to the CSV import data (see image below). At the moment, we do not have an interface for the data that is coming into our application from the class list CSV file. We then declare `: any` multiple times more in the application and continue on with this trend. Did we want to use Types as much as possible? I believe so.
![image](https://user-images.githubusercontent.com/7872295/61007039-ad1ab380-a320-11e9-9691-abbe9300c241.png)

We can also ask Reid for his feedback on how he would like to see this application evolve, such as how to 
abstract new code that we introduce. For example, the business logic that we implemented, which is our new code highlighted in green in this pull-request, _might_ not best fit in the CSV Parser class. It is business logic that may fit better in another class. However, I am happy to keep things simple for now as well.