### PR TITLE
Adding in necessary suffix for successful Docker image build

### DIFF
--- a/packages/portal/frontend/html/admin.html
+++ b/packages/portal/frontend/html/admin.html
@@ -913,8 +913,8 @@
                         </div>
                         <div class="expandable-content">
                             See <a href="https://docs.docker.com/engine/reference/commandline/build/#git-repositories">docker build</a>
-                            documentation for details about how to construct the URL. The URL should start with "https://". If the
-                            repository is private, set GH_DOCKER_TOKEN in the .env. Do not include the token in the URL.
+                            documentation for details about how to construct the URL. The URL should start with "https://" and end with 
+                            ".git" suffix. If the repository is private, set GH_DOCKER_TOKEN in the .env. Do not include the token in the URL.
                         </div>
                     </ons-list-item>
 


### PR DESCRIPTION
Documentation change: https://github.com/ubccpsctech/classy/issues/2

From the testing that I have seen, without the .git suffix, the repo import fails.