### PR TITLE
Failure info is in message string property. Proper reference needed f…

### DIFF
--- a/packages/portal/frontend/src/app/views/AdminProvisionPage.ts
+++ b/packages/portal/frontend/src/app/views/AdminProvisionPage.ts
@@ -364,7 +364,7 @@ export class AdminProvisionPage extends AdminPage {
             Log.info('AdminProvisioningPage::getProvisionDetails(..) - success; took: ' + Util.took(start));
             return json.success;
         } else {
-            Log.error('AdminProvisioningPage::getProvisionDetails(..) - ERROR: ' + json.failure);
+            Log.error('AdminProvisioningPage::getProvisionDetails(..) - ERROR: ' + json.failure.message);
         }
         return [];
     }


### PR DESCRIPTION
…or error logging

Improperly referenced JSON. Instead, we want to see the JSON message property.