### PR TITLE
Feature/default script

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -263,6 +263,8 @@ cd /opt/classy
 docker network create --attachable --ip-range "172.28.5.0/24" --gateway "172.28.5.254" --subnet "172.28.0.0/16" grading_net
 
 # Copy default front-end and back-end templates to customizable files needed to run Classy:
+./helper-scripts/default-file-setup.sh
+# Or if you have yarn: (runs the same script, see package.json)
 yarn run pre-build
 
 docker-compose build

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -262,6 +262,9 @@ cd /opt/classy
 # Create a subnet that the grading containers will attach to. This makes it easier to set up firewall rules (above).
 docker network create --attachable --ip-range "172.28.5.0/24" --gateway "172.28.5.254" --subnet "172.28.0.0/16" grading_net
 
+# Copy default front-end and back-end templates to customizable files needed to run Classy:
+yarn run pre-build
+
 docker-compose build
 ```
 

--- a/docs/fork-customization.md
+++ b/docs/fork-customization.md
@@ -21,15 +21,15 @@ If you are famiiar with the MVC pattern and would like to modify the view, famil
 
 ### HTML:
 
-packages/portal/frontend/html/{*name*}/custom.html
-packages/portal/frontend/html/{*name*}/landing.html
-packages/portal/frontend/html/{*name*}/login.html
-packages/portal/frontend/html/{*name*}/student.html
+- packages/portal/frontend/html/{*name*}/custom.html
+- packages/portal/frontend/html/{*name*}/landing.html
+- packages/portal/frontend/html/{*name*}/login.html
+- packages/portal/frontend/html/{*name*}/student.html
 
 ### View Models:
 
-packages/portal/frontend/src/app/custom/CustomStudentView.ts
-packages/portal/frontend/src/app/custom/CustomAdminView.ts
+- packages/portal/frontend/src/app/custom/CustomStudentView.ts
+- packages/portal/frontend/src/app/custom/CustomAdminView.ts
 
 You may modify any of these files generated above. Any custom logic may also be implemented in the 'Custom' view model files if the files continue to extend the  `AdminView` and `AbstractStudentView` classes. Any number of subclasses can also be contained in this folder.  These changes should ***NOT*** be pushed back to `classy/master`.
 
@@ -39,8 +39,8 @@ The back-end uses Restify, a RESTful API server, to provide data to the front-en
 
 ### Customizable Back-end Files:
 
-- `Classy/packages/portal/backend/src/custom/CustomCourseRoutes.ts`
-- `Classy/packages/portal/backend/src/custom/CustomCourseController.ts`
+- Classy/packages/portal/backend/src/custom/CustomCourseRoutes.ts
+- Classy/packages/portal/backend/src/custom/CustomCourseController.ts
 
 `CustomCourseController.ts` extends `CourseController` because it is used in the most common course-specific overrides that require code. 
 

--- a/docs/fork-customization.md
+++ b/docs/fork-customization.md
@@ -6,23 +6,10 @@ Process Overview: Fork Code from Root Classy Repository --> Optional: Modify For
 
 ## Front-End Customization
 
-The front-end uses Onsen UI, which is a lightweight UI framework that uses vanilla Javascript and HTML templates in a MVC pattern. If a fork would like to modify the default views in Classy, it is necessary to create these custom files from their default counterparts:
+The front-end uses Onsen UI, which is a lightweight UI framework that uses vanilla Javascript and HTML templates in a MVC pattern. UI components and instructions for writing Custom View Model logic can be found here: https://onsen.io/v2/guide/#getting-started. If you are famiiar with the MVC pattern and would like to modify the views:
 
-**IF you create Custom HTML Views, you must ALSO create custom view models**
-
-### Step 1: CREATE CUSTOM HTML VIEWS
-
-- Copy the contents of `Classy/packages/portal/frontend/html/default` to `Classy/packages/portal/frontend/html/*name*`. The name variable MUST be the `name` variable found in `Classy/.env`)
-- The previous step copies the REQUIRED HTML templates: `landing.html`, `login.html`, and `student.html`. Any custom HTML templates may be added here.
-
-UI components and instructions for writing Custom View Model logic can be found here: https://onsen.io/v2/guide/#getting-started.
-
-### Step 2: CREATE CUSTOM VIEW MODELS
-
-In `Classy/packages/portal/frontend/src/app/custom`:
-
-- Copy `./DefaultAdminView.ts` to `./CustomAdminView.ts`
-- Copy `./DefaultStudentView.ts` to `./CustomStudentView.ts`
+- Modify any of the HTML templates under `Classy/packages/portal/frontend/html/*name*`
+- Modify any of the View Models with the `Custom` filename prefixes found under `Classy/packages/portal/frontend/src/app/custom`
 
 Any custom logic may be implemented in the 'Custom' view model files if the files continue to extend the  `AdminView` and `AbstractStudentView` classes. Any number of subclasses can also be contained in this folder. These changes should ***NOT*** be pushed back to `classy/master`.
 

--- a/docs/fork-customization.md
+++ b/docs/fork-customization.md
@@ -46,9 +46,9 @@ The back-end uses Restify, a RESTful API server, to provide data to the front-en
 
 `CustomCourseRoutes.ts` implements `IREST`, which allows you to define any custom REST routes required by the backend. Any number of subclasses can also be contained in this folder. These changes should ***NOT*** be pushed back to `classy/master`.
 
-## Restoring the Default State
+## Restoring Default Application State
 
-The original default files can be found in `default-file-setup.sh`. To revert to the default state, remove all of the custom files from front-end and back-end, and re-run `default-file-setup.sh`.
+The default files used to create the custom boilerplate files can be found in the `default-file-setup.sh` script. To revert to the default state, remove all of the custom files from front-end and back-end applications, and then re-run `default-file-setup.sh` from the `./Classy` directory.
 
 ## Test Fork Customization 
 

--- a/docs/fork-customization.md
+++ b/docs/fork-customization.md
@@ -4,23 +4,51 @@ Each CPSC course that uses Classy requires a fork of the `root` https://github.c
 
 Process Overview: Fork Code from Root Classy Repository --> Optional: Modify Forked Classy Code --> Technical Staff Hosts Code on Server
 
-## Front-End Customization
+## Classy Customization
 
-The front-end uses Onsen UI, which is a lightweight UI framework that uses vanilla Javascript and HTML templates in a MVC pattern. UI components and instructions for writing Custom View Model logic can be found here: https://onsen.io/v2/guide/#getting-started. If you are famiiar with the MVC pattern and would like to modify the views:
+Classy requires that a set of custom files are implemented for each course offering. These files allow you to customize your course by modifying the views on the front-end and the controller logic on the back-end. As most courses require very standard logic, custom files can automatically be generated from default boilerplates. To generate your custom files: 
 
-- Modify any of the HTML templates under `Classy/packages/portal/frontend/html/*name*`
-- Modify any of the View Models with the `Custom` filename prefixes found under `Classy/packages/portal/frontend/src/app/custom`
+- Double-check that your `.env` file `NAME` property contains your course name. The file may be found in the root `./Classy/.env`.
+- Then, run the Bash script `./helper-scripts/default-file-setup.sh` from the root `./Classy` directory.
 
-Any custom logic may be implemented in the 'Custom' view model files if the files continue to extend the  `AdminView` and `AbstractStudentView` classes. Any number of subclasses can also be contained in this folder. These changes should ***NOT*** be pushed back to `classy/master`.
+By running the Bash script above, files will be generated that allow you to either (a.) run the application with its defaults or (b.) modify the code to achieve unique business logic requirements. 
 
-## Back-End Customization
+## Modifying the Front-end
 
-The back-end uses Restify, a RESTful API server, to provide data to the front-end. Customized boilerplate files are loaded into Restify at start-up. These boilerplate files may be modified:
+The front-end uses Onsen UI, which is a lightweight framework that uses vanilla Javascript and HTML templates in a MVC pattern. UI components and instructions for writing Custom View Model logic can be found here: https://onsen.io/v2/guide/#getting-started.
+
+If you are famiiar with the MVC pattern and would like to modify the view, familiarize yourself with the set of custom files that are generated:
+
+### HTML:
+
+packages/portal/frontend/html/{*name*}/custom.html
+packages/portal/frontend/html/{*name*}/landing.html
+packages/portal/frontend/html/{*name*}/login.html
+packages/portal/frontend/html/{*name*}/student.html
+
+### View Models:
+
+packages/portal/frontend/src/app/custom/CustomStudentView.ts
+packages/portal/frontend/src/app/custom/CustomAdminView.ts
+
+You may modify any of these files generated above. Any custom logic may also be implemented in the 'Custom' view model files if the files continue to extend the  `AdminView` and `AbstractStudentView` classes. Any number of subclasses can also be contained in this folder.  These changes should ***NOT*** be pushed back to `classy/master`.
+
+## Modifying the Back-end
+
+The back-end uses Restify, a RESTful API server, to provide data to the front-end. Customized boilerplate files are loaded by Restify at start-up. These boilerplate files may also be modified:
+
+### Customizable Back-end Files:
 
 - `Classy/packages/portal/backend/src/custom/CustomCourseRoutes.ts`
-- `Classy/packages/portal/backend/src/custom/CustomCoursecontroller.ts`
+- `Classy/packages/portal/backend/src/custom/CustomCourseController.ts`
 
-Any number of subclasses can also be contained in this folder. These changes should ***NOT*** be pushed back to `classy/master`.
+`CustomCourseController.ts` extends `CourseController` because it is used in the most common course-specific overrides that require code. 
+
+`CustomCourseRoutes.ts` implements `IREST`, which allows you to define any custom REST routes required by the backend. Any number of subclasses can also be contained in this folder. These changes should ***NOT*** be pushed back to `classy/master`.
+
+## Restoring the Default State
+
+The original default files can be found in `default-file-setup.sh`. To revert to the default state, remove all of the custom files from front-end and back-end, and re-run `default-file-setup.sh`.
 
 ## Test Fork Customization 
 

--- a/docs/fork-customization.md
+++ b/docs/fork-customization.md
@@ -15,12 +15,10 @@ Any custom logic may be implemented in the 'Custom' view model files if the file
 
 ## Back-End Customization
 
-The back-end uses Restify, a RESTful API server, to provide data to the front-end. A customized Course Controller and Course Routes class, respectively, MUST be implemented.
+The back-end uses Restify, a RESTful API server, to provide data to the front-end. Customized boilerplate files are loaded into Restify at start-up. These boilerplate files may be modified:
 
-To implement custom Course Controller and Course Routes, in `Classy/packages/portal/backend/src/custom`:
-
-* Copy `DefaultCourseController.ts` to create `CustomCourseController.ts` in the same directory. `CustomCourseController` extends `CourseController` because it is used in the most common course-specific overrides that require code.
-* Copy `DefaultCourseRoutes.ts` to create `CustomCourseRoutes.ts` in the same directory. `CustomCourseRoutes.ts` implements `IREST`, which allows you to define any custom REST routes required by the backend.
+- `Classy/packages/portal/backend/src/custom/CustomCourseRoutes.ts`
+- `Classy/packages/portal/backend/src/custom/CustomCoursecontroller.ts`
 
 Any number of subclasses can also be contained in this folder. These changes should ***NOT*** be pushed back to `classy/master`.
 

--- a/helper-scripts/default-file-setup.sh
+++ b/helper-scripts/default-file-setup.sh
@@ -56,7 +56,7 @@ function doesFileExist() {
 }
 
 ## Creates Custom boilerplate files from Default files
-## -i flag to not overwrite just to be safe
+## -n flag to not overwrite just to be safe
 function copyFiles() {
 	echo "default-file-setup.sh:: copyFiles() started - BACKEND"
 	cp -nv "packages/portal/backend/src/custom/DefaultCourseRoutes.ts" "packages/portal/backend/src/custom/CustomCourseRoutes.ts"

--- a/helper-scripts/default-file-setup.sh
+++ b/helper-scripts/default-file-setup.sh
@@ -12,19 +12,26 @@ version=1.0.0
 envFile=".env"
 envVar=''
 
-frontendFiles=(packages/portal/frontend/src/app/custom/CustomAdminView.ts 
-	packages/portal/frontend/src/app/custom/CustomStudentView.ts)
+setFilenames() {
+	backendFiles=(packages/portal/backend/src/custom/CustomCourseRoutes.ts
+		packages/portal/backend/src/custom/CustomCourseController.ts)
 
-backendFiles=(packages/portal/backend/src/custom/CustomCourseRoutes.ts
-	packages/portal/backend/src/custom/CustomCourseController.ts)
+	frontendFiles=(packages/portal/frontend/src/app/custom/CustomStudentView.ts
+		packages/portal/frontend/src/app/custom/CustomAdminView.ts
+		packages/portal/frontend/html/${envVar}/custom.html
+		packages/portal/frontend/html/${envVar}/landing.html
+		packages/portal/frontend/html/${envVar}/login.html
+		packages/portal/frontend/html/${envVar}/student.html
+	)
+}
 
 function main() {
 	echo "default-file-setup.sh:: starting script version ${version}..."
 	cd ..
 	setEnvName
+	setFilenames
 	preCopy
 	copyFiles
-	# postFileChecks
 	exit 0
 }
 
@@ -32,7 +39,6 @@ function preCopy() {
 	## 1. Check that files do not already exist.
 	doesFileExist "${frontendFiles[@]}"
 	doesFileExist "${backendFiles[@]}"
-	## 2. Check that envVar can be set; needed for subdirectory path creation
 }
 
 ## Exits if a matching file is found
@@ -41,7 +47,7 @@ function doesFileExist() {
 	filenameList=("$@")
 	for filename in "${filenameList[@]}"
 		do
-			if [ -f $filename ]; then
+			if [ -f "${filename}" ]; then
 				echo "default-file-setup.sh:: doesFileExist ERROR: File ${filename} exists!"
 				echo "default-file-setup.sh:: CANNOT CREATE CUSTOM FILES IF A CUSTOM FILE ALREADY EXISTS. ALL CUSTOM FILES MUST BE REMOVED BEFORE RE-CREATING CUSTOM FILES FROM DEFAULTS"
 				exit 1
@@ -58,22 +64,15 @@ function copyFiles() {
 
 	echo "default-file-setup.sh:: copyFiles() started - FRONTEND"
 	## VIEW MODELS
-	cp -nv "packages/portal/frontend/src/custom/DefaultStudentView.ts" "packages/portal/frontend/src/custom/CustomStudentView.ts"
-	cp -nv "packages/portal/frontend/src/custom/DefaultAdminView.ts" "packages/portal/frontend/src/custom/CustomAdminView.ts"
+	cp -nv "packages/portal/frontend/src/app/custom/DefaultStudentView.ts" "packages/portal/frontend/src/app/custom/CustomStudentView.ts"
+	cp -nv "packages/portal/frontend/src/app/custom/DefaultAdminView.ts" "packages/portal/frontend/src/app/custom/CustomAdminView.ts"
 
 	## HTML VIEWS
-	mkdir -p "packages/portal/frontend/html/${CUSTOM_NAME}/"
+	mkdir -p "packages/portal/frontend/html/${envVar}/"
 	cp -nv "packages/portal/frontend/html/default/custom.html" "packages/portal/frontend/html/${envVar}/custom.html"
-	cp -nv "packages/portal/frontend/html/default/custom.html" "packages/portal/frontend/html/${envVar}/landing.html"
-	cp -nv "packages/portal/frontend/html/default/custom.html" "packages/portal/frontend/html/${envVar}/login.html"
-	cp -nv "packages/portal/frontend/html/default/custom.html" "packages/portal/frontend/html/${envVar}/default.html"
-
-	# filenamesMap=("$@")
-	# for filenames in "${!filenamesMap[@]}"
-		# do
-		# 	echo "default-file-setup.sh:: copyFrontend() - copying ${filenames} to ${filenamesMap[$filenames]}"
-		# done
-	# cp -i
+	cp -nv "packages/portal/frontend/html/default/landing.html" "packages/portal/frontend/html/${envVar}/landing.html"
+	cp -nv "packages/portal/frontend/html/default/login.html" "packages/portal/frontend/html/${envVar}/login.html"
+	cp -nv "packages/portal/frontend/html/default/student.html" "packages/portal/frontend/html/${envVar}/student.html"
 }
 
 function setEnvName() {

--- a/helper-scripts/default-file-setup.sh
+++ b/helper-scripts/default-file-setup.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+###################################
+# Create front-end and back-end boierplate customization files if they do not exist. This script takes default boierplate files and copies them over into 
+# filenames that are used for customized logic in Classy
+#
+# steca - 
+# IMPORTANT: Aborts if any previous custom file is found.
+
+set e
+version=1.0.0
+envFile=".env"
+envVar=''
+
+frontendFiles=(packages/portal/frontend/src/app/custom/CustomAdminView.ts 
+	packages/portal/frontend/src/app/custom/CustomStudentView.ts)
+
+backendFiles=(packages/portal/backend/src/custom/CustomCourseRoutes.ts
+	packages/portal/backend/src/custom/CustomCourseController.ts)
+
+function main() {
+	echo "default-file-setup.sh:: starting script version ${version}..."
+	cd ..
+	setEnvName
+	preCopy
+	copyFiles
+	# postFileChecks
+	exit 0
+}
+
+function preCopy() {
+	## 1. Check that files do not already exist.
+	doesFileExist "${frontendFiles[@]}"
+	doesFileExist "${backendFiles[@]}"
+	## 2. Check that envVar can be set; needed for subdirectory path creation
+}
+
+## Exits if a matching file is found
+function doesFileExist() {
+	echo "default-file-setup.sh:: doesFileExist started"
+	filenameList=("$@")
+	for filename in "${filenameList[@]}"
+		do
+			if [ -f $filename ]; then
+				echo "default-file-setup.sh:: doesFileExist ERROR: File ${filename} exists!"
+				echo "default-file-setup.sh:: CANNOT CREATE CUSTOM FILES IF A CUSTOM FILE ALREADY EXISTS. ALL CUSTOM FILES MUST BE REMOVED BEFORE RE-CREATING CUSTOM FILES FROM DEFAULTS"
+				exit 1
+			fi
+		done
+}
+
+## Creates Custom boilerplate files from Default files
+## -i flag to not overwrite just to be safe
+function copyFiles() {
+	echo "default-file-setup.sh:: copyFiles() started - BACKEND"
+	cp -nv "packages/portal/backend/src/custom/DefaultCourseRoutes.ts" "packages/portal/backend/src/custom/CustomCourseRoutes.ts"
+	cp -nv "packages/portal/backend/src/custom/DefaultCourseController.ts" "packages/portal/backend/src/custom/CustomCourseController.ts"
+
+	echo "default-file-setup.sh:: copyFiles() started - FRONTEND"
+	## VIEW MODELS
+	cp -nv "packages/portal/frontend/src/custom/DefaultStudentView.ts" "packages/portal/frontend/src/custom/CustomStudentView.ts"
+	cp -nv "packages/portal/frontend/src/custom/DefaultAdminView.ts" "packages/portal/frontend/src/custom/CustomAdminView.ts"
+
+	## HTML VIEWS
+	mkdir -p "packages/portal/frontend/html/${CUSTOM_NAME}/"
+	cp -nv "packages/portal/frontend/html/default/custom.html" "packages/portal/frontend/html/${envVar}/custom.html"
+	cp -nv "packages/portal/frontend/html/default/custom.html" "packages/portal/frontend/html/${envVar}/landing.html"
+	cp -nv "packages/portal/frontend/html/default/custom.html" "packages/portal/frontend/html/${envVar}/login.html"
+	cp -nv "packages/portal/frontend/html/default/custom.html" "packages/portal/frontend/html/${envVar}/default.html"
+
+	# filenamesMap=("$@")
+	# for filenames in "${!filenamesMap[@]}"
+		# do
+		# 	echo "default-file-setup.sh:: copyFrontend() - copying ${filenames} to ${filenamesMap[$filenames]}"
+		# done
+	# cp -i
+}
+
+function setEnvName() {
+	echo "default-file-setup.sh:: setEnvName() started"
+	declare lastLine
+	while read line; 
+		do 
+			## HACK because multiple NAME= strings exist in file
+			if [[ "${lastLine}" =~ "## Name of the org" ]]; 
+				then
+					envVar=$(echo "${line}" | cut -d"=" -f 2)
+					echo "default-file-setup.sh:: setEnvName() Set envVar to ${envVar}"
+				fi
+			lastLine=${line}
+	done < ${envFile}
+
+	if [ $envVar == '' ]; then
+		echo "default-file-setup.sh:: setEnvName() ERROR - COULD NOT FIND NAME PROPERTY IN CLASSY .env FILE. MAKE SURE IT IS BELOW '## Name of the org' LINE"
+		exit 1
+	fi
+}
+
+main

--- a/helper-scripts/default-file-setup.sh
+++ b/helper-scripts/default-file-setup.sh
@@ -6,93 +6,65 @@
 #
 # steca - 
 # IMPORTANT: Aborts if any previous custom file is found.
+#
+# This should be run from the base folder, i.e. /opt/classy
 
-set e
+set -e
+
 version=1.0.0
+echo "default-file-setup.sh:: starting script version ${version}..."
+
 envFile=".env"
-envVar=''
+envVar=`awk -F = '/^NAME[[:space:]]*=/{gsub(/[[:space:]]/, "", $2); print $2}' ${envFile}`
+if [ $envVar == '' ]; then
+	echo "default-file-setup.sh:: ERROR - COULD NOT FIND NAME PROPERTY IN ${envFile}"
+	exit 1
+fi
+echo "default-file-setup.sh:: envVar = ${envVar}"
 
-setFilenames() {
-	backendFiles=(packages/portal/backend/src/custom/CustomCourseRoutes.ts
-		packages/portal/backend/src/custom/CustomCourseController.ts)
 
-	frontendFiles=(packages/portal/frontend/src/app/custom/CustomStudentView.ts
-		packages/portal/frontend/src/app/custom/CustomAdminView.ts
-		packages/portal/frontend/html/${envVar}/custom.html
-		packages/portal/frontend/html/${envVar}/landing.html
-		packages/portal/frontend/html/${envVar}/login.html
-		packages/portal/frontend/html/${envVar}/student.html
-	)
-}
+customFiles=(packages/portal/backend/src/custom/CustomCourseRoutes.ts
+	packages/portal/backend/src/custom/CustomCourseController.ts
+	packages/portal/frontend/src/app/custom/CustomStudentView.ts
+	packages/portal/frontend/src/app/custom/CustomAdminView.ts
+	packages/portal/frontend/html/${envVar}/custom.html
+	packages/portal/frontend/html/${envVar}/landing.html
+	packages/portal/frontend/html/${envVar}/login.html
+	packages/portal/frontend/html/${envVar}/student.html
+)
 
-function main() {
-	echo "default-file-setup.sh:: starting script version ${version}..."
-	cd ..
-	setEnvName
-	setFilenames
-	preCopy
-	copyFiles
-	exit 0
-}
 
-function preCopy() {
-	## 1. Check that files do not already exist.
-	doesFileExist "${frontendFiles[@]}"
-	doesFileExist "${backendFiles[@]}"
-}
-
+## 1. Check that files do not already exist.
 ## Exits if a matching file is found
-function doesFileExist() {
-	echo "default-file-setup.sh:: doesFileExist started"
-	filenameList=("$@")
-	for filename in "${filenameList[@]}"
-		do
-			if [ -f "${filename}" ]; then
-				echo "default-file-setup.sh:: doesFileExist ERROR: File ${filename} exists!"
-				echo "default-file-setup.sh:: CANNOT CREATE CUSTOM FILES IF A CUSTOM FILE ALREADY EXISTS. ALL CUSTOM FILES MUST BE REMOVED BEFORE RE-CREATING CUSTOM FILES FROM DEFAULTS"
-				exit 1
-			fi
-		done
-}
-
-## Creates Custom boilerplate files from Default files
-## -n flag to not overwrite just to be safe
-function copyFiles() {
-	echo "default-file-setup.sh:: copyFiles() started - BACKEND"
-	cp -nv "packages/portal/backend/src/custom/DefaultCourseRoutes.ts" "packages/portal/backend/src/custom/CustomCourseRoutes.ts"
-	cp -nv "packages/portal/backend/src/custom/DefaultCourseController.ts" "packages/portal/backend/src/custom/CustomCourseController.ts"
-
-	echo "default-file-setup.sh:: copyFiles() started - FRONTEND"
-	## VIEW MODELS
-	cp -nv "packages/portal/frontend/src/app/custom/DefaultStudentView.ts" "packages/portal/frontend/src/app/custom/CustomStudentView.ts"
-	cp -nv "packages/portal/frontend/src/app/custom/DefaultAdminView.ts" "packages/portal/frontend/src/app/custom/CustomAdminView.ts"
-
-	## HTML VIEWS
-	mkdir -p "packages/portal/frontend/html/${envVar}/"
-	cp -nv "packages/portal/frontend/html/default/custom.html" "packages/portal/frontend/html/${envVar}/custom.html"
-	cp -nv "packages/portal/frontend/html/default/landing.html" "packages/portal/frontend/html/${envVar}/landing.html"
-	cp -nv "packages/portal/frontend/html/default/login.html" "packages/portal/frontend/html/${envVar}/login.html"
-	cp -nv "packages/portal/frontend/html/default/student.html" "packages/portal/frontend/html/${envVar}/student.html"
-}
-
-function setEnvName() {
-	echo "default-file-setup.sh:: setEnvName() started"
-	declare lastLine
-	while read line; 
-		do 
-			## HACK because multiple NAME= strings exist in file
-			if [[ "${lastLine}" =~ "## Name of the org" ]]; 
-				then
-					envVar=$(echo "${line}" | cut -d"=" -f 2)
-					echo "default-file-setup.sh:: setEnvName() Set envVar to ${envVar}"
-				fi
-			lastLine=${line}
-	done < ${envFile}
-
-	if [ $envVar == '' ]; then
-		echo "default-file-setup.sh:: setEnvName() ERROR - COULD NOT FIND NAME PROPERTY IN CLASSY .env FILE. MAKE SURE IT IS BELOW '## Name of the org' LINE"
+for filename in "${customFiles[@]}"
+do
+	if [ -f "${filename}" ]; then
+		echo "default-file-setup.sh:: ERROR: File ${filename} exists!"
+		echo "default-file-setup.sh:: CANNOT CREATE CUSTOM FILES IF A CUSTOM FILE ALREADY EXISTS. ALL CUSTOM FILES MUST BE REMOVED BEFORE RE-CREATING CUSTOM FILES FROM DEFAULTS"
 		exit 1
 	fi
-}
+done
 
-main
+
+## 2. Create custom boilerplate files from default files
+## -n flag to not overwrite just to be safe
+
+echo "default-file-setup.sh:: starting to copy defaults to custom"
+
+## FRONTEND - HTML VIEWS
+# If mkdir fails, we want this to stop: if the parent doesn't exist, there's a problem...
+mkdir -v "packages/portal/frontend/html/${envVar}/"
+cp -nv "packages/portal/frontend/html/default/custom.html" "packages/portal/frontend/html/${envVar}/custom.html"
+cp -nv "packages/portal/frontend/html/default/landing.html" "packages/portal/frontend/html/${envVar}/landing.html"
+cp -nv "packages/portal/frontend/html/default/login.html" "packages/portal/frontend/html/${envVar}/login.html"
+cp -nv "packages/portal/frontend/html/default/student.html" "packages/portal/frontend/html/${envVar}/student.html"
+
+## FRONTEND - VIEW MODELS
+cp -nv "packages/portal/frontend/src/app/custom/DefaultStudentView.ts" "packages/portal/frontend/src/app/custom/CustomStudentView.ts"
+cp -nv "packages/portal/frontend/src/app/custom/DefaultAdminView.ts" "packages/portal/frontend/src/app/custom/CustomAdminView.ts"
+
+## BACKEND
+cp -nv "packages/portal/backend/src/custom/DefaultCourseRoutes.ts" "packages/portal/backend/src/custom/CustomCourseRoutes.ts"
+cp -nv "packages/portal/backend/src/custom/DefaultCourseController.ts" "packages/portal/backend/src/custom/CustomCourseController.ts"
+
+echo "default-file-setup.sh:: custom files successfully created from defaults"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     },
     "scripts": {
         "postinstall": "git config core.hooksPath .githooks",
-        "pre-build": "cd helper-scripts && ./default-file-setup.sh && cd ..",
+        "pre-build": "./helper-scripts/default-file-setup.sh",
         "build": "tsc",
         "build:prod": "tsc --outDir bin --sourceMap false",
         "lintOLD": "tslint -c tslint.json 'packages/portal/backend/src/**/*.ts' 'packages/portal/backend/test/**/*.ts' 'packages/portal/frontend/src/**/*.ts' 'packages/portal/frontend/test/**/*.ts' 'packages/autotest/src/**/*.ts' 'packages/autotest/test/**/*.ts'",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     },
     "scripts": {
         "postinstall": "git config core.hooksPath .githooks",
+        "pre-build": "cd helper-scripts && ./default-file-setup.sh && cd ..",
         "build": "tsc",
         "build:prod": "tsc --outDir bin --sourceMap false",
         "lintOLD": "tslint -c tslint.json 'packages/portal/backend/src/**/*.ts' 'packages/portal/backend/test/**/*.ts' 'packages/portal/frontend/src/**/*.ts' 'packages/portal/frontend/test/**/*.ts' 'packages/autotest/src/**/*.ts' 'packages/autotest/test/**/*.ts'",

--- a/packages/portal/Dockerfile
+++ b/packages/portal/Dockerfile
@@ -12,10 +12,8 @@ COPY .env ./
 COPY package.json tsconfig.json .env ./
 COPY packages/common ./packages/common
 COPY packages/portal ./packages/portal
-COPY helper-scripts ./helper-scripts
 
-RUN cd helper-scripts && ./default-file-setup.sh && cd .. \
- && yarn install --pure-lockfile --non-interactive --ignore-scripts \
+RUN yarn install --pure-lockfile --non-interactive --ignore-scripts \
  && yarn tsc --sourceMap false \
  && cd packages/portal/frontend && yarn webpack \
  && chmod -R a+r /app \

--- a/packages/portal/Dockerfile
+++ b/packages/portal/Dockerfile
@@ -7,8 +7,6 @@ RUN apk add --no-cache git
 
 WORKDIR /app
 
-RUN ./helper-scripts/default-file-setup.sh
-
 # The common package requires the .env file directly so we have to pass it through
 COPY .env ./
 COPY package.json tsconfig.json .env ./

--- a/packages/portal/Dockerfile
+++ b/packages/portal/Dockerfile
@@ -14,7 +14,7 @@ COPY packages/common ./packages/common
 COPY packages/portal ./packages/portal
 COPY helper-scripts ./helper-scripts
 
-RUN yarn run pre-build \
+RUN cd helper-scripts && ./default-file-setup.sh && cd .. \
  && yarn install --pure-lockfile --non-interactive --ignore-scripts \
  && yarn tsc --sourceMap false \
  && cd packages/portal/frontend && yarn webpack \

--- a/packages/portal/Dockerfile
+++ b/packages/portal/Dockerfile
@@ -13,7 +13,7 @@ COPY package.json tsconfig.json .env ./
 COPY packages/common ./packages/common
 COPY packages/portal ./packages/portal
 
-RUN yarn run prebuild \
+RUN yarn run pre-build \
  && yarn install --pure-lockfile --non-interactive --ignore-scripts \
  && yarn tsc --sourceMap false \
  && cd packages/portal/frontend && yarn webpack \

--- a/packages/portal/Dockerfile
+++ b/packages/portal/Dockerfile
@@ -13,7 +13,7 @@ COPY package.json tsconfig.json .env ./
 COPY packages/common ./packages/common
 COPY packages/portal ./packages/portal
 
-RUN cd helper-scripts && ./default-file-setup.sh && cd .. \
+RUN yarn run prebuild \
  && yarn install --pure-lockfile --non-interactive --ignore-scripts \
  && yarn tsc --sourceMap false \
  && cd packages/portal/frontend && yarn webpack \

--- a/packages/portal/Dockerfile
+++ b/packages/portal/Dockerfile
@@ -15,7 +15,8 @@ COPY package.json tsconfig.json .env ./
 COPY packages/common ./packages/common
 COPY packages/portal ./packages/portal
 
-RUN yarn install --pure-lockfile --non-interactive --ignore-scripts \
+RUN pushd ./helper-scripts && ./default-file-setup.sh && pulld \
+ && yarn install --pure-lockfile --non-interactive --ignore-scripts \
  && yarn tsc --sourceMap false \
  && cd packages/portal/frontend && yarn webpack \
  && chmod -R a+r /app \

--- a/packages/portal/Dockerfile
+++ b/packages/portal/Dockerfile
@@ -12,6 +12,7 @@ COPY .env ./
 COPY package.json tsconfig.json .env ./
 COPY packages/common ./packages/common
 COPY packages/portal ./packages/portal
+COPY helper-scripts ./helper-scripts
 
 RUN yarn run pre-build \
  && yarn install --pure-lockfile --non-interactive --ignore-scripts \

--- a/packages/portal/Dockerfile
+++ b/packages/portal/Dockerfile
@@ -7,6 +7,8 @@ RUN apk add --no-cache git
 
 WORKDIR /app
 
+RUN ./helper-scripts/default-file-setup.sh
+
 # The common package requires the .env file directly so we have to pass it through
 COPY .env ./
 COPY package.json tsconfig.json .env ./

--- a/packages/portal/Dockerfile
+++ b/packages/portal/Dockerfile
@@ -13,7 +13,7 @@ COPY package.json tsconfig.json .env ./
 COPY packages/common ./packages/common
 COPY packages/portal ./packages/portal
 
-RUN pushd ./helper-scripts && ./default-file-setup.sh && pulld \
+RUN cd helper-scripts && ./default-file-setup.sh && cd .. \
  && yarn install --pure-lockfile --non-interactive --ignore-scripts \
  && yarn tsc --sourceMap false \
  && cd packages/portal/frontend && yarn webpack \


### PR DESCRIPTION
This pre-build step is added to the `yarn run` commands as `yarn run pre-build` in the root directory of the `Classy` project. 

The step automatically copies default boilerplate code into custom files that can be modified to change the front-end views and back-end route/controller logic of the application.

This command does not run automatically as part of the Docker build process. It MUST be run before the `docker-compose build` command before bootstrapping an application because the Docker containers use Sh and Ash, which are incompatible with the Bash script logic (alternatively, we can install bash onto the Docker images to allow this step to be automated). The build logic documentation has been updated to include this step.