### PR TITLE
Feature/split classlist endpoint logic

### DIFF
--- a/packages/portal/backend/src/server/common/GeneralRoutes.ts
+++ b/packages/portal/backend/src/server/common/GeneralRoutes.ts
@@ -313,7 +313,7 @@ export default class GeneralRoutes implements IREST {
         const ca = new ClasslistAgent();
         const ipAddr = req.headers['x-forwarded-for'] || req.connection.remoteAddress;
         const host = req.headers['host'];
-        const ipReg: RegExp = /(142\.103\.5\.[1-9])/;
+        const ipReg: RegExp = /(142\.103\.[1-9]\.[1-9])/;
         let auditInfo: string;
 
         if (ipReg.test(ipAddr) === false && host.includes('localhost') === false) {

--- a/packages/portal/backend/src/server/common/GeneralRoutes.ts
+++ b/packages/portal/backend/src/server/common/GeneralRoutes.ts
@@ -312,7 +312,6 @@ export default class GeneralRoutes implements IREST {
         const pc = new PersonController();
         const ca = new ClasslistAgent();
         const ipAddr = req.headers['x-forwarded-for'] || req.connection.remoteAddress;
-        const host = req.headers['host'];
         const ipReg: RegExp = /(142\.103\.[1-9]+\.[1-9]+)/;
         let auditInfo: string;
 

--- a/packages/portal/backend/src/server/common/GeneralRoutes.ts
+++ b/packages/portal/backend/src/server/common/GeneralRoutes.ts
@@ -317,7 +317,7 @@ export default class GeneralRoutes implements IREST {
         let auditInfo: string;
 
         if (ipReg.test(ipAddr) === false && host.includes('localhost') === false) {
-            await GeneralRoutes.handleError(403, 'Forbidden error; user not privileged', res, next);
+            return await GeneralRoutes.handleError(403, 'Forbidden error; user not privileged', res, next);
         }
 
         auditInfo = req.headers.user || ipAddr;

--- a/packages/portal/backend/src/server/common/GeneralRoutes.ts
+++ b/packages/portal/backend/src/server/common/GeneralRoutes.ts
@@ -313,10 +313,10 @@ export default class GeneralRoutes implements IREST {
         const ca = new ClasslistAgent();
         const ipAddr = req.headers['x-forwarded-for'] || req.connection.remoteAddress;
         const host = req.headers['host'];
-        const ipReg: RegExp = /(142\.103\.[1-9]\.[1-9])/;
+        const ipReg: RegExp = /(142\.103\.[1-9]+\.[1-9]+)/;
         let auditInfo: string;
 
-        if (ipReg.test(ipAddr) === false && host.includes('localhost') === false) {
+        if (ipReg.test(ipAddr) === false) {
             return await GeneralRoutes.handleError(403, 'Forbidden error; user not privileged', res, next);
         }
 

--- a/packages/portal/backend/test/server/AdminRoutesSpec.ts
+++ b/packages/portal/backend/test/server/AdminRoutesSpec.ts
@@ -1294,4 +1294,34 @@ describe('Admin Routes', function() {
         expect(body.failure).to.not.be.undefined;
         expect(ex).to.be.null;
     });
+
+    it('Should be able to update a classlist if authorized as admin', async function() {
+        let response = null;
+        let body: Payload;
+        const url = '/portal/admin/classlist';
+        try {
+            response = await request(app).put(url).set({user: userName, token: userToken});
+            body = response.body;
+        } catch (err) {
+            Log.test('ERROR: ' + err);
+        }
+
+        expect(body).to.haveOwnProperty('success');
+        expect(body.success).to.haveOwnProperty('message');
+        expect(body.success.message).to.contain('Classlist upload successful');
+    });
+
+    it('Should NOT be able to update a classlist if not authorized as admin', async function() {
+        let response = null;
+        let body: Payload;
+        const url = '/portal/admin/classlist';
+        try {
+            response = await request(app).put(url);
+            body = response.body;
+        } catch (err) {
+            Log.test('ERROR: ' + err);
+        }
+
+        expect(body).to.haveOwnProperty('failure');
+    });
 });

--- a/packages/portal/backend/test/server/GeneralRoutesSpec.ts
+++ b/packages/portal/backend/test/server/GeneralRoutesSpec.ts
@@ -121,20 +121,20 @@ describe('General Routes', function() {
         expect(body.success.githubId).to.equal(Test.USER1.github);
     });
 
-    it('Should NOT be able to update a classlist on if NOT on localhost and on a 143.103.*.* IP', async function() {
+    it('Should NOT be able to update a classlist if NOT on a 143.103.*.* IP', async function() {
         let response = null;
         let body: Payload;
         const url = '/portal/classlist';
         try {
             response = await request(app).put(url)
-                .set('test-include-xfwd', '')
-                .set('x-forwarded-for', '142.103.5.99')
+                .set('x-forwarded-for', '152.99.5.99')
                 .set('Host', 'www.google.ca');
             body = response.body;
-            expect(body).to.haveOwnProperty('failure');
         } catch (err) {
             Log.test('ERROR: ' + err);
         }
+
+        expect(body).to.haveOwnProperty('failure');
     });
 
     it('Should be able to update a classlist on restricted IP', async function() {
@@ -146,10 +146,12 @@ describe('General Routes', function() {
                 .set('test-include-xfwd', '')
                 .set('x-forwarded-for', '142.103.5.99');
             body = response.body;
-            expect(JSON.stringify(body)).to.haveOwnProperty('success');
         } catch (err) {
             Log.test('ERROR: ' + err);
         }
+        expect(body).to.haveOwnProperty('success');
+        expect(body.success).to.haveOwnProperty('message');
+        expect(body.success.message).to.contain('Classlist upload successful');
     });
 
     it('Should not be able to get a person without the right token.', async function() {

--- a/packages/portal/backend/test/server/GeneralRoutesSpec.ts
+++ b/packages/portal/backend/test/server/GeneralRoutesSpec.ts
@@ -121,22 +121,7 @@ describe('General Routes', function() {
         expect(body.success.githubId).to.equal(Test.USER1.github);
     });
 
-    it('Should be able to update a classlist on localhost', async function() {
-        let response = null;
-        let body: Payload;
-
-        const url = '/portal/classlist';
-        try {
-            response = await request(app).put(url).set('Host', 'localhost');
-            body = response.body;
-            expect(body).to.haveOwnProperty('success');
-            expect(body.success.message).to.equal('Classlist upload successful. 3 students processed.');
-        } catch (err) {
-            Log.test('ERROR: ' + err);
-        }
-    });
-
-    it('Should NOT be able to update a classlist on if NOT on localhost and on a 143.103.5 IP', async function() {
+    it('Should NOT be able to update a classlist on if NOT on localhost and on a 143.103.*.* IP', async function() {
         let response = null;
         let body: Payload;
         const url = '/portal/classlist';

--- a/packages/portal/frontend/src/app/views/AdminConfigTab.ts
+++ b/packages/portal/frontend/src/app/views/AdminConfigTab.ts
@@ -417,7 +417,7 @@ export class AdminConfigTab extends AdminPage {
 
     private async updateClasslistPressed(): Promise<void> {
         Log.trace('AdminConfigTab::updateClasslistPressed(..) - start');
-        const url = this.remote + '/portal/classlist';
+        const url = this.remote + '/portal/admin/classlist';
         const options: any = AdminView.getOptions();
         options.method = 'put';
 


### PR DESCRIPTION
Classlist update route split into two routes: 

- General Route will allow any IP 142.103.*.* trigger this route logic. 
- A General Route localhost restriction was removed.

- Admin Route will only be accessible by admins. 

Tests written, and RegEx issue fixed.