### PR TITLE
Feature/circle ci frontend build test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
 
       - run:
             command: cd packages/portal/frontend && ../../../node_modules/typescript/bin/tsc && yarn webpack
-            name: Compile front-end TypeScript and compile Webpack
+            name: Building frontend and bundle with Webpack
             when: always
 
       # statically validate the frontend (this is the best we can do as there are no automated UI tests yet)


### PR DESCRIPTION
@winstan 

This is a minor change I just developed in isolation. It can be merged into the `master` or `feature/circle-ci-github-dev-make-script-new-env` branch. It best belongs in the `feature/circle-ci-github-dev-make-script-new-env` branch because of how the project is setup though.

This change pre-bundles the front-end with Webpack before we get to the stage where we build the Docker containers on an instance. This minor and quick step in Circle CI should stop some big surprises.