### PR TITLE
Removes team creator, which is added by Github by default, on team cr…

### DIFF
--- a/packages/portal/backend/src/controllers/GitHubActions.ts
+++ b/packages/portal/backend/src/controllers/GitHubActions.ts
@@ -835,6 +835,11 @@ export class GitHubActions implements IGitHubActions {
                 const url = config.getProp(ConfigKey.githubHost) + "/orgs/" + config.getProp(ConfigKey.org) + "/teams/" + teamName;
                 // TODO: simplify callees by setting Team.URL here and persisting it (like we do with createRepo)
                 Log.info("GitHubAction::teamCreate(..) - success; new: " + id + "; took: " + Util.took(start));
+
+                // remove default token provider/maintainer from team
+                await this.removeMembersFromTeam(teamName,
+                    [Config.getInstance().getProp(ConfigKey.githubBotName)]);
+
                 return {teamName: teamName, githubTeamNumber: id, URL: url};
             }
         } catch (err) {


### PR DESCRIPTION
Continued from PR https://github.com/ubccpsctech/classy/pull/95.

- Removes the Github Bot/Token Provider from a team after it is created.
- Github Bot/Token Provider removed before additional team members added.
- Backwards compatible, as no error is thrown when removing a team member who does not exist on team.