### PR TITLE
Fixes front-end console error that blocks deliverable params from loa…

### DIFF
--- a/packages/portal/frontend/src/app/views/AdminConfigTab.ts
+++ b/packages/portal/frontend/src/app/views/AdminConfigTab.ts
@@ -231,23 +231,23 @@ export class AdminConfigTab extends AdminPage {
             });
         };
 
-        (document.querySelector('#adminManagePullRequestsButton') as OnsButtonElement).onclick = function(evt) {
-            Log.info('AdminConfigTab::handleAdminConfig(..) - manage PRs page pressed');
-            evt.preventDefault();
+        // (document.querySelector('#adminManagePullRequestsButton') as OnsButtonElement).onclick = function(evt) {
+        //     Log.info('AdminConfigTab::handleAdminConfig(..) - manage PRs page pressed');
+        //     evt.preventDefault();
 
-            that.pushPage('./adminPullRequests.html', {}).then(function() {
-                const pullRequestsPage = new AdminPullRequestsPage(that.remote);
-                pullRequestsPage.init({}).then(function() {
-                    // success
-                    Log.info('AdminConfigTab::handleAdminConfig(..) - PRs page init');
-                }).catch(function(err) {
-                    // error
-                    Log.error('AdminConfigTab::handleAdminConfig(..) - PRs page ERROR: ' + err);
-                });
-            }).catch(function(err) {
-                Log.error("AdminConfigTab - adminPullRequests ERROR: " + err.message);
-            });
-        };
+        //     that.pushPage('./adminPullRequests.html', {}).then(function() {
+        //         const pullRequestsPage = new AdminPullRequestsPage(that.remote);
+        //         pullRequestsPage.init({}).then(function() {
+        //             // success
+        //             Log.info('AdminConfigTab::handleAdminConfig(..) - PRs page init');
+        //         }).catch(function(err) {
+        //             // error
+        //             Log.error('AdminConfigTab::handleAdminConfig(..) - PRs page ERROR: ' + err);
+        //         });
+        //     }).catch(function(err) {
+        //         Log.error("AdminConfigTab - adminPullRequests ERROR: " + err.message);
+        //     });
+        // };
 
         (document.querySelector('#adminPerformWithdrawButton') as OnsButtonElement).onclick = function(evt) {
             Log.info('AdminConfigTab::handleAdminConfig(..) - perform withdraw pressed');


### PR DESCRIPTION
- A listener that was watching for the pull-request HTML failed, which blocked deliverable parameters from loading.
- The pull-request HTML was commented out prior to this request.