### PR TITLE
Unpinning version, as by default running secure > 12.15.0; https://no…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.15.0-alpine
+FROM node:12-alpine
 
 WORKDIR /app
 COPY package.json tsconfig.json .env ./

--- a/packages/autotest/Dockerfile
+++ b/packages/autotest/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.15.0-alpine
+FROM node:12-alpine
 
 RUN apk add --no-cache git
 

--- a/packages/portal/Dockerfile
+++ b/packages/portal/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.15.0-alpine
+FROM node:12-alpine
 
 ARG GH_BOT_EMAIL=classy@cs.ubc.ca
 ARG GH_BOT_USERNAME=classy


### PR DESCRIPTION
It is no longer necessary to pin the version of Node, as by default secure versions are being pulled.