### PR TITLE
Resetting user kind to null on login to trigger re-check for Github a…

### DIFF
--- a/packages/portal/backend/src/server/common/AuthRoutes.ts
+++ b/packages/portal/backend/src/server/common/AuthRoutes.ts
@@ -320,6 +320,13 @@ export class AuthRoutes implements IREST {
             };
 
             await DatabaseController.getInstance().writeAuth(auth);
+
+            // updates user role on login. withdrawn students cannot login and therefore are not affected.
+            person.kind = null;
+            await new PersonController().writePerson(person);
+
+            Log.trace("AuthRoutes::performAuthCallback(..) - person kind reset on login: " + JSON.stringify(person));
+
             Log.trace("AuthRoutes::performAuthCallback(..) - preparing redirect for: " + JSON.stringify(person));
 
             Log.trace("AuthRoutes::performAuthCallback(..) - /authCallback - redirect hostname: " + feUrl + "; fePort: " + fePort);


### PR DESCRIPTION
From issue: https://github.com/ubccpsctech/classy/issues/90.

Users who login for the first time will be added to Classy's database with a user `kind` based on their Github Team memberships (ie. Student, staff, or admin). 

If a user logs in again, Classy retrieves the user from the database without re-checking the team permissions. Hence, if the team permissions change, the user will be stuck with the user kind of when the user was initially created. 

This fix sets the person `kind` field as `null` when a user is authenticating, which forces Classy to re-run some logic to check the user kind based on the current Github team membership state.