### PR TITLE
Updating ConfigTransport type to include list of deliverables with co…

### DIFF
--- a/packages/common/types/PortalTypes.ts
+++ b/packages/common/types/PortalTypes.ts
@@ -48,7 +48,7 @@ export interface ConfigTransport {
     org: string;
     name: string;
     githubAPI: string;
-    teamDeliverableIds: string[];
+    studentsFormTeamDelivIds: string[];
 }
 
 export interface CourseTransportPayload {

--- a/packages/common/types/PortalTypes.ts
+++ b/packages/common/types/PortalTypes.ts
@@ -32,6 +32,7 @@ export interface ClasslistChangesTransport {
     created: StudentTransport[];
     removed: StudentTransport[];
     classlist: StudentTransport[];
+    message: string;
 }
 
 export interface ClasslistChangesTransportPayload {

--- a/packages/common/types/PortalTypes.ts
+++ b/packages/common/types/PortalTypes.ts
@@ -48,7 +48,7 @@ export interface ConfigTransport {
     org: string;
     name: string;
     githubAPI: string;
-    deliverables: Deliverable[];
+    teamDeliverableIds: string[];
 }
 
 export interface CourseTransportPayload {

--- a/packages/common/types/PortalTypes.ts
+++ b/packages/common/types/PortalTypes.ts
@@ -8,6 +8,8 @@
 import {AutoTestResult} from "./AutoTestTypes";
 import {ClusteredResult} from "./ContainerTypes";
 
+import {Deliverable} from "../../portal/backend/src/Types";
+
 export interface FailurePayload {
     message: string;
     shouldLogout: boolean; // almost always false
@@ -46,6 +48,7 @@ export interface ConfigTransport {
     org: string;
     name: string;
     githubAPI: string;
+    deliverables: Deliverable[];
 }
 
 export interface CourseTransportPayload {

--- a/packages/portal/backend/src/server/common/ClasslistAgent.ts
+++ b/packages/portal/backend/src/server/common/ClasslistAgent.ts
@@ -66,6 +66,7 @@ export class ClasslistAgent {
         });
 
         const changeReport: ClasslistChangesTransport = {
+            message: 'Successfully uploaded classlist.',
             created: [], // new registrations
             updated: [], // only students whose CWL or lab has changed
             removed: [], // precludes withdrawn students; next step should be to withdraw students who end up appearing here

--- a/packages/portal/backend/src/server/common/GeneralRoutes.ts
+++ b/packages/portal/backend/src/server/common/GeneralRoutes.ts
@@ -70,11 +70,13 @@ export default class GeneralRoutes implements IREST {
         const org = Config.getInstance().getProp(ConfigKey.org);
         const name = Config.getInstance().getProp(ConfigKey.name);
         const githubAPI = Config.getInstance().getProp(ConfigKey.githubAPI);
-        const teamDeliverableIds = (await new DeliverablesController().getAllDeliverables()).map((d) => d.id);
+        const studentsFormTeamDelivIds = (await new DeliverablesController().getAllDeliverables())
+            .filter((d) => d.teamStudentsForm === true)
+            .map((d) => d.id);
 
         let payload: ConfigTransportPayload;
         if (org !== null) {
-            payload = {success: {org: org, name: name, githubAPI: githubAPI, teamDeliverableIds}};
+            payload = {success: {org: org, name: name, githubAPI: githubAPI, studentsFormTeamDelivIds}};
             Log.trace('GeneralRoutes::getConfig(..) - sending: ' + JSON.stringify(payload));
             res.send(200, payload);
             return next(false);

--- a/packages/portal/backend/src/server/common/GeneralRoutes.ts
+++ b/packages/portal/backend/src/server/common/GeneralRoutes.ts
@@ -64,16 +64,17 @@ export default class GeneralRoutes implements IREST {
         server.put('/portal/classlist', GeneralRoutes.updateClasslist);
     }
 
-    public static getConfig(req: any, res: any, next: any) {
+    public static async getConfig(req: any, res: any, next: any) {
         Log.info('GeneralRoutes::getConfig(..) - start');
 
         const org = Config.getInstance().getProp(ConfigKey.org);
         const name = Config.getInstance().getProp(ConfigKey.name);
         const githubAPI = Config.getInstance().getProp(ConfigKey.githubAPI);
+        const deliverables = await new DeliverablesController().getAllDeliverables();
 
         let payload: ConfigTransportPayload;
         if (org !== null) {
-            payload = {success: {org: org, name: name, githubAPI: githubAPI}};
+            payload = {success: {org: org, name: name, githubAPI: githubAPI, deliverables}};
             Log.trace('GeneralRoutes::getConfig(..) - sending: ' + JSON.stringify(payload));
             res.send(200, payload);
             return next(false);

--- a/packages/portal/backend/src/server/common/GeneralRoutes.ts
+++ b/packages/portal/backend/src/server/common/GeneralRoutes.ts
@@ -70,11 +70,11 @@ export default class GeneralRoutes implements IREST {
         const org = Config.getInstance().getProp(ConfigKey.org);
         const name = Config.getInstance().getProp(ConfigKey.name);
         const githubAPI = Config.getInstance().getProp(ConfigKey.githubAPI);
-        const deliverables = await new DeliverablesController().getAllDeliverables();
+        const teamDeliverableIds = (await new DeliverablesController().getAllDeliverables()).map((d) => d.id);
 
         let payload: ConfigTransportPayload;
         if (org !== null) {
-            payload = {success: {org: org, name: name, githubAPI: githubAPI, deliverables}};
+            payload = {success: {org: org, name: name, githubAPI: githubAPI, teamDeliverableIds}};
             Log.trace('GeneralRoutes::getConfig(..) - sending: ' + JSON.stringify(payload));
             res.send(200, payload);
             return next(false);

--- a/packages/portal/backend/test/server/GeneralRoutesSpec.ts
+++ b/packages/portal/backend/test/server/GeneralRoutesSpec.ts
@@ -10,6 +10,7 @@ import Log from "../../../../common/Log";
 import {Test} from "../../../../common/TestHarness";
 import {ConfigTransportPayload, Payload, TeamFormationTransport} from "../../../../common/types/PortalTypes";
 import {DatabaseController} from "../../src/controllers/DatabaseController";
+import {DeliverablesController} from "../../src/controllers/DeliverablesController";
 import {RepositoryController} from "../../src/controllers/RepositoryController";
 import BackendServer from "../../src/server/BackendServer";
 
@@ -70,7 +71,6 @@ describe('General Routes', function() {
     });
 
     it('Should be able to get config details', async function() {
-
         let response = null;
         let body: ConfigTransportPayload;
         const url = '/portal/config';
@@ -81,13 +81,17 @@ describe('General Routes', function() {
             Log.test('ERROR: ' + err);
         }
         Log.test(response.status + " -> " + JSON.stringify(body));
+        const dc = new DeliverablesController();
+        const studentsFormTeamDelivIds = (await dc.getAllDeliverables())
+            .filter((d) => d.teamStudentsForm === true)
+            .map((d) => d.id);
         expect(response.status).to.equal(200);
         expect(body.success).to.not.be.undefined;
         expect(body.success.org).to.not.be.undefined;
         expect(body.success.org).to.equal(Config.getInstance().getProp(ConfigKey.org)); // valid .org usage
         expect(body.success.name).to.equal(Config.getInstance().getProp(ConfigKey.name));
         expect(body.success.studentsFormTeamDelivIds.length).to.equal(4);
-        expect(body.success.studentsFormTeamDelivIds).to.eql(['d0', 'd1', 'd2', 'project']);
+        expect(body.success.studentsFormTeamDelivIds).to.eql(studentsFormTeamDelivIds);
     });
 
     it('Should be able to get a person.', async function() {

--- a/packages/portal/backend/test/server/GeneralRoutesSpec.ts
+++ b/packages/portal/backend/test/server/GeneralRoutesSpec.ts
@@ -86,7 +86,7 @@ describe('General Routes', function() {
         expect(body.success.org).to.not.be.undefined;
         expect(body.success.org).to.equal(Config.getInstance().getProp(ConfigKey.org)); // valid .org usage
         expect(body.success.name).to.equal(Config.getInstance().getProp(ConfigKey.name));
-        expect(body.success.deliverables.length).to.equal(1);
+        expect(body.success.teamDeliverableIds.length).to.equal(1);
     });
 
     it('Should be able to get a person.', async function() {

--- a/packages/portal/backend/test/server/GeneralRoutesSpec.ts
+++ b/packages/portal/backend/test/server/GeneralRoutesSpec.ts
@@ -86,7 +86,8 @@ describe('General Routes', function() {
         expect(body.success.org).to.not.be.undefined;
         expect(body.success.org).to.equal(Config.getInstance().getProp(ConfigKey.org)); // valid .org usage
         expect(body.success.name).to.equal(Config.getInstance().getProp(ConfigKey.name));
-        expect(body.success.teamDeliverableIds.length).to.equal(1);
+        expect(body.success.teamDeliverableIds.length).to.equal(5);
+        expect(body.success.teamDeliverableIds).to.eql(['d0', 'd1', 'd2', 'd3', 'project']);
     });
 
     it('Should be able to get a person.', async function() {

--- a/packages/portal/backend/test/server/GeneralRoutesSpec.ts
+++ b/packages/portal/backend/test/server/GeneralRoutesSpec.ts
@@ -86,8 +86,8 @@ describe('General Routes', function() {
         expect(body.success.org).to.not.be.undefined;
         expect(body.success.org).to.equal(Config.getInstance().getProp(ConfigKey.org)); // valid .org usage
         expect(body.success.name).to.equal(Config.getInstance().getProp(ConfigKey.name));
-        expect(body.success.studentsFormTeamDelivIds.length).to.equal(5);
-        expect(body.success.studentsFormTeamDelivIds).to.eql(['d0', 'd1', 'd2', 'd3', 'project']);
+        expect(body.success.studentsFormTeamDelivIds.length).to.equal(4);
+        expect(body.success.studentsFormTeamDelivIds).to.eql(['d0', 'd1', 'd2', 'project']);
     });
 
     it('Should be able to get a person.', async function() {

--- a/packages/portal/backend/test/server/GeneralRoutesSpec.ts
+++ b/packages/portal/backend/test/server/GeneralRoutesSpec.ts
@@ -86,6 +86,7 @@ describe('General Routes', function() {
         expect(body.success.org).to.not.be.undefined;
         expect(body.success.org).to.equal(Config.getInstance().getProp(ConfigKey.org)); // valid .org usage
         expect(body.success.name).to.equal(Config.getInstance().getProp(ConfigKey.name));
+        expect(body.success.deliverables.length).to.equal(1);
     });
 
     it('Should be able to get a person.', async function() {

--- a/packages/portal/backend/test/server/GeneralRoutesSpec.ts
+++ b/packages/portal/backend/test/server/GeneralRoutesSpec.ts
@@ -86,8 +86,8 @@ describe('General Routes', function() {
         expect(body.success.org).to.not.be.undefined;
         expect(body.success.org).to.equal(Config.getInstance().getProp(ConfigKey.org)); // valid .org usage
         expect(body.success.name).to.equal(Config.getInstance().getProp(ConfigKey.name));
-        expect(body.success.teamDeliverableIds.length).to.equal(5);
-        expect(body.success.teamDeliverableIds).to.eql(['d0', 'd1', 'd2', 'd3', 'project']);
+        expect(body.success.studentsFormTeamDelivIds.length).to.equal(5);
+        expect(body.success.studentsFormTeamDelivIds).to.eql(['d0', 'd1', 'd2', 'd3', 'project']);
     });
 
     it('Should be able to get a person.', async function() {

--- a/packages/portal/frontend/html/admin.html
+++ b/packages/portal/frontend/html/admin.html
@@ -165,6 +165,20 @@
         </ons-page>
     </template>
 
+    <template id="classlistDialog.html">
+        <ons-dialog id="adminClasslistConfirmHeader">
+            <ons-list-header style="text-align: center; font-weight: 700">
+            </ons-list-header>
+            <ons-scroller>
+                <ons-list>
+                </ons-list>
+            </ons-scroller>
+            <ons-button>
+                Close
+            </ons-button>
+        </ons-dialog>
+    </template>
+
     <template id="dockerBuildDialog.html">
         <ons-dialog id="adminDockerBuildDialog">
             <div id="adminDockerBuildDialog-header-container">
@@ -949,7 +963,8 @@
                             </div>
                             <div class="expandable-content">
                                 Delay (in seconds) that students must wait between requesting AutoTest feedback.
-                                E.g., 0 for no feedback limit (not recommended!), 43200 (12 hours), 86400 (24 hours).
+                                E.g., 900 (15 minutes), 43200 (12 hours), 86400 (24 hours). Cannot be lower than
+                                15 minutes unless a minimum value is set in the environmental config.
                             </div>
                         </ons-list-item>
 

--- a/packages/portal/frontend/html/default/student.html
+++ b/packages/portal/frontend/html/default/student.html
@@ -18,7 +18,7 @@
         <ons-list-item>
             <div id="studentRepoTable" style="width:100%;"></div>
         </ons-list-item>
-        <div id="studentSelectPartnerDiv" style="display: none;"> <!-- -->
+        <div id="studentSelectPartnerDiv"> <!-- -->
             <ons-list-header>Select Project Partner</ons-list-header>
             <ons-list-item expandable>
                 <div class="left settingIcon">
@@ -42,7 +42,7 @@
                 Specify deliverable:
             </div>
             <div>
-                <ons-select id="studentSelectDeliverable" onchange="myApp.view.editDelivSelection(this.value)">
+                <ons-select id="studentSelectDeliverable">
                 </ons-select>
             </div>
             <div class="expandable-content">
@@ -52,10 +52,10 @@
         <ons-list-item expandable id="studentNoDeliverableTeamFormation">
             No deliverables are configured for student team formation. Please contact TAs or instructor if you think this is a mistake.
         </ons-list-item>
-        <div id="studentPartnerDiv" style="display: none;">
+        <div id="studentPartnerDiv">
             <ons-list-header>Current Teams</ons-list-header>
-            <ons-list-item>
-                You are not on any teams.
+            <ons-list-item id="studentNotOnTeamMsg">
+                You currently are not on any teams.
             </ons-list-item>
         </div>
     </ons-list>

--- a/packages/portal/frontend/html/default/student.html
+++ b/packages/portal/frontend/html/default/student.html
@@ -53,10 +53,9 @@
             No deliverables are configured for student team formation. Please contact TAs or instructor if you think this is a mistake.
         </ons-list-item>
         <div id="studentPartnerDiv" style="display: none;">
-            <ons-list-header>Project Partner</ons-list-header>
+            <ons-list-header>Current Teams</ons-list-header>
             <ons-list-item>
-                Your team is&nbsp;<span id="studentPartnerTeamName"></span>.
-                <!--; your teammate is&nbsp;<span id="studentPartnerTeammates"></span>.-->
+                You are not on any teams.
             </ons-list-item>
         </div>
     </ons-list>

--- a/packages/portal/frontend/html/default/student.html
+++ b/packages/portal/frontend/html/default/student.html
@@ -49,9 +49,6 @@
                 Select the deliverable that you would like to form a team for. Only deliverables configured for student team formation are listed.
             </div>
         </ons-list-item>
-        <ons-list-item expandable id="studentNoDeliverableTeamFormation">
-            No deliverables are configured for student team formation. Please contact TAs or instructor if you think this is a mistake.
-        </ons-list-item>
         <div id="studentPartnerDiv">
             <ons-list-header>Current Teams</ons-list-header>
             <ons-list-item id="studentNotOnTeamMsg">

--- a/packages/portal/frontend/html/default/student.html
+++ b/packages/portal/frontend/html/default/student.html
@@ -42,11 +42,8 @@
                 Specify deliverable:
             </div>
             <div>
-                <ons-select id="studentSelectDeliverable" onchange="editSelects(event)">
-                    <option value="basic">test</option>
-                    <option value="material">Material</option>
-                    <option value="underbar">Underbar</option>
-                  </ons-select>
+                <ons-select id="studentSelectDeliverable" onchange="myApp.view.editDelivSelection(this.value)">
+                </ons-select>
             </div>
             <div class="expandable-content">
                 Select the deliverable that you would like to form a team for. Only deliverables configured for student team formation are listed.

--- a/packages/portal/frontend/html/default/student.html
+++ b/packages/portal/frontend/html/default/student.html
@@ -36,6 +36,25 @@
                 </div>
             </ons-list-item>
         </div>
+        <ons-list-item expandable>
+            <div class="left settingIcon">
+                <ons-icon style="padding-right: 1em;" icon="fa-microchip"></ons-icon>
+                Specify deliverable:
+            </div>
+            <div>
+                <ons-select id="studentSelectDeliverable" onchange="editSelects(event)">
+                    <option value="basic">test</option>
+                    <option value="material">Material</option>
+                    <option value="underbar">Underbar</option>
+                  </ons-select>
+            </div>
+            <div class="expandable-content">
+                Select the deliverable that you would like to form a team for. Only deliverables configured for student team formation are listed.
+            </div>
+        </ons-list-item>
+        <ons-list-item expandable id="studentNoDeliverableTeamFormation">
+            No deliverables are configured for student team formation. Please contact TAs or instructor if you think this is a mistake.
+        </ons-list-item>
         <div id="studentPartnerDiv" style="display: none;">
             <ons-list-header>Project Partner</ons-list-header>
             <ons-list-item>

--- a/packages/portal/frontend/html/style.css
+++ b/packages/portal/frontend/html/style.css
@@ -153,3 +153,16 @@ stdio viewer Page
 #adminDockerBuildDialog .dialog {
     height: 80vh;
 }
+
+/**
+  CSS for Classlist API update change report
+*/
+#adminClasslistConfirmHeader ons-list {
+    overflow-y: auto;
+    height: 80vh;
+}
+
+#adminClasslistConfirmHeader ons-button {
+    text-align: center;
+    width: 100%;
+}

--- a/packages/portal/frontend/src/app/App.ts
+++ b/packages/portal/frontend/src/app/App.ts
@@ -416,11 +416,11 @@ export class App {
                 return json.success;
             } else {
                 Log.error('App::retrieveConfig() - failed: ' + JSON.stringify(json) + ')');
-                return {org: 'ERROR', name: 'ERROR', githubAPI: null, deliverables: null};
+                return {org: 'ERROR', name: 'ERROR', githubAPI: null, teamDeliverableIds: null};
             }
         } else {
             Log.error('App::retrieveConfig() - ERROR');
-            return {org: 'ERROR', name: 'ERROR', githubAPI: null, deliverables: null};
+            return {org: 'ERROR', name: 'ERROR', githubAPI: null, teamDeliverableIds: null};
         }
     }
 

--- a/packages/portal/frontend/src/app/App.ts
+++ b/packages/portal/frontend/src/app/App.ts
@@ -416,11 +416,11 @@ export class App {
                 return json.success;
             } else {
                 Log.error('App::retrieveConfig() - failed: ' + JSON.stringify(json) + ')');
-                return {org: 'ERROR', name: 'ERROR', githubAPI: null};
+                return {org: 'ERROR', name: 'ERROR', githubAPI: null, deliverables: null};
             }
         } else {
             Log.error('App::retrieveConfig() - ERROR');
-            return {org: 'ERROR', name: 'ERROR', githubAPI: null};
+            return {org: 'ERROR', name: 'ERROR', githubAPI: null, deliverables: null};
         }
     }
 

--- a/packages/portal/frontend/src/app/App.ts
+++ b/packages/portal/frontend/src/app/App.ts
@@ -416,11 +416,11 @@ export class App {
                 return json.success;
             } else {
                 Log.error('App::retrieveConfig() - failed: ' + JSON.stringify(json) + ')');
-                return {org: 'ERROR', name: 'ERROR', githubAPI: null, teamDeliverableIds: null};
+                return {org: 'ERROR', name: 'ERROR', githubAPI: null, studentsFormTeamDelivIds: null};
             }
         } else {
             Log.error('App::retrieveConfig() - ERROR');
-            return {org: 'ERROR', name: 'ERROR', githubAPI: null, teamDeliverableIds: null};
+            return {org: 'ERROR', name: 'ERROR', githubAPI: null, studentsFormTeamDelivIds: null};
         }
     }
 

--- a/packages/portal/frontend/src/app/custom/DefaultStudentView.ts
+++ b/packages/portal/frontend/src/app/custom/DefaultStudentView.ts
@@ -111,44 +111,35 @@ export class DefaultStudentView extends AbstractStudentView {
         UI.hideSection('studentSelectPartnerDiv');
         UI.hideSection('studentPartnerDiv');
 
-        // skip this all for now; we will redeploy when teams can be formed
-        // if (Date.now() > 0) {
-        //     return;
-        // }
-
-        if (teams.length === 0) {
-            // no team yet
-
-            const button = document.querySelector('#studentSelectPartnerButton') as OnsButtonElement;
-            button.onclick = function(evt: any) {
-                Log.info('DefaultStudentView::renderTeams(..)::createTeam::onClick');
-                that.formTeam().then(function(team) {
-                    Log.info('DefaultStudentView::renderTeams(..)::createTeam::onClick::then - team created');
-                    that.teams.push(team);
-                    if (team !== null) {
-                        that.renderPage({}); // simulating refresh
-                    }
-                }).catch(function(err) {
-                    Log.info('DefaultStudentView::renderTeams(..)::createTeam::onClick::catch - ERROR: ' + err);
-                });
-            };
-
-            UI.showSection('studentSelectPartnerDiv');
-        } else {
-            // already on team
-            UI.showSection('studentPartnerDiv');
-
-            const teamElement = document.getElementById('studentPartnerTeamName');
-            // const partnerElement = document.getElementById('studentPartnerTeammates');
-
-            if (teams.length) {
-                for (let i = 1; i < teamsListDiv.children.length; i++) {
-                    teamsListDiv.children[i].remove();
+        // configure team creation menus
+        const button = document.querySelector('#studentSelectPartnerButton') as OnsButtonElement;
+        button.onclick = function(evt: any) {
+            Log.info('DefaultStudentView::renderTeams(..)::createTeam::onClick');
+            that.formTeam().then(function(team) {
+                Log.info('DefaultStudentView::renderTeams(..)::createTeam::onClick::then - team created');
+                that.teams.push(team);
+                if (team !== null) {
+                    that.renderPage({}); // simulating refresh
                 }
-                for (const team of teams) {
-                    const item = UI.createListItem(team.id);
-                    teamsListDiv.appendChild(item);
-                }
+            }).catch(function(err) {
+                Log.info('DefaultStudentView::renderTeams(..)::createTeam::onClick::catch - ERROR: ' + err);
+            });
+        };
+
+        UI.showSection('studentSelectPartnerDiv');
+        // already on team
+        UI.showSection('studentPartnerDiv');
+
+        const teamElement = document.getElementById('studentPartnerTeamName');
+        // const partnerElement = document.getElementById('studentPartnerTeammates');
+
+        if (teams.length) {
+            for (let i = 1; i < teamsListDiv.children.length; i++) {
+                teamsListDiv.children[i].remove();
+            }
+            for (const team of teams) {
+                const item = UI.createListItem(team.id);
+                teamsListDiv.appendChild(item);
             }
         }
     }

--- a/packages/portal/frontend/src/app/custom/DefaultStudentView.ts
+++ b/packages/portal/frontend/src/app/custom/DefaultStudentView.ts
@@ -104,7 +104,6 @@ export class DefaultStudentView extends AbstractStudentView {
     private async renderTeams(teams: TeamTransport[]): Promise<void> {
         Log.trace('DefaultStudentView::renderTeams(..) - start');
         const that = this;
-        const teamsListDiv = document.getElementById('studentPartnerDiv');
 
         // configure team creation menus
         const button = document.querySelector('#studentSelectPartnerButton') as OnsButtonElement;
@@ -121,6 +120,7 @@ export class DefaultStudentView extends AbstractStudentView {
             });
         };
 
+        const teamsListDiv = document.getElementById('studentPartnerDiv');
         const teamElement = document.getElementById('studentPartnerTeamName');
 
         if (teams.length) {
@@ -143,12 +143,13 @@ export class DefaultStudentView extends AbstractStudentView {
 
     private async formTeam(): Promise<TeamTransport> {
         Log.info("DefaultStudentView::formTeam() - start");
-        const otherId = UI.getTextFieldValue('studentSelectPartnerText');
+        const studentSelectPartner = document.getElementById('studentSelectPartnerText') as HTMLInputElement;
+        const otherIds = studentSelectPartner.value.replace(' ', '').split(',');
         const delivMenu = document.getElementById('studentSelectDeliverable') as OnsSelectElement;
         const myGithubId = this.getStudent().githubId;
         const payload: TeamFormationTransport = {
             delivId:   delivMenu.options[delivMenu.selectedIndex].value,
-            githubIds: [myGithubId, otherId]
+            githubIds: [myGithubId, ...otherIds]
         };
         const url = this.remote + '/portal/team';
         const options: any = this.getOptions();
@@ -166,6 +167,8 @@ export class DefaultStudentView extends AbstractStudentView {
 
         if (typeof body.success !== 'undefined') {
             // worked
+            UI.notification('Team ' + body.success[0].id + ' created.');
+            studentSelectPartner.value = '';
             return body.success as TeamTransport;
         } else if (typeof body.failure !== 'undefined') {
             // failed

--- a/packages/portal/frontend/src/app/custom/DefaultStudentView.ts
+++ b/packages/portal/frontend/src/app/custom/DefaultStudentView.ts
@@ -22,7 +22,7 @@ export interface TeamFormationDeliverable {
 export class DefaultStudentView extends AbstractStudentView {
 
     private teams: TeamTransport[];
-    private teamDeliverableIds: string[];
+    private studentsFormTeamDelivIds: string[];
 
     constructor(remoteUrl: string) {
         super();
@@ -63,8 +63,8 @@ export class DefaultStudentView extends AbstractStudentView {
             await this.renderTeams(teams);
 
             // team deliverable selection rendered here
-            this.teamDeliverableIds = await this.fetchStudentFormTeamDelivs();
-            await this.renderDeliverableSelectMenu(this.teamDeliverableIds);
+            this.studentsFormTeamDelivIds = await this.fetchStudentFormTeamDelivs();
+            await this.renderDeliverableSelectMenu(this.studentsFormTeamDelivIds);
 
             Log.info('DefaultStudentView::renderStudentPage(..) - done');
         } catch (err) {
@@ -76,10 +76,10 @@ export class DefaultStudentView extends AbstractStudentView {
 
     private async fetchStudentFormTeamDelivs(): Promise<string[]> {
         try {
-            this.teamDeliverableIds = null;
+            this.studentsFormTeamDelivIds = null;
             const data: ConfigTransport = await this.fetchData('/portal/config');
             Log.info('ClassyStudentView::fetchStudentFormTeamDelivs(..) - data', data);
-            return data.teamDeliverableIds;
+            return data.studentsFormTeamDelivIds;
         } catch (err) {
             Log.error('ClassyStudentView::fetchStudentFormTeamDelivs(..) - ERROR ', err);
         }
@@ -188,7 +188,7 @@ export class DefaultStudentView extends AbstractStudentView {
                 delivSelect.firstChild.appendChild(opt);
             });
         }
-        Log.info(this.teamDeliverableIds);
+        Log.info(this.studentsFormTeamDelivIds);
     }
 
 }

--- a/packages/portal/frontend/src/app/custom/DefaultStudentView.ts
+++ b/packages/portal/frontend/src/app/custom/DefaultStudentView.ts
@@ -105,6 +105,7 @@ export class DefaultStudentView extends AbstractStudentView {
     private async renderTeams(teams: TeamTransport[]): Promise<void> {
         Log.trace('DefaultStudentView::renderTeams(..) - start');
         const that = this;
+        const teamsListDiv = document.getElementById('studentPartnerDiv');
 
         // make sure these are hidden
         UI.hideSection('studentSelectPartnerDiv');
@@ -115,14 +116,7 @@ export class DefaultStudentView extends AbstractStudentView {
         //     return;
         // }
 
-        let projectTeam = null;
-        for (const team of teams) {
-            if (team.delivId === "project") {
-                projectTeam = team;
-            }
-        }
-
-        if (projectTeam === null) {
+        if (teams.length === 0) {
             // no team yet
 
             const button = document.querySelector('#studentSelectPartnerButton') as OnsButtonElement;
@@ -146,8 +140,16 @@ export class DefaultStudentView extends AbstractStudentView {
 
             const teamElement = document.getElementById('studentPartnerTeamName');
             // const partnerElement = document.getElementById('studentPartnerTeammates');
-            const team = projectTeam;
-            teamElement.innerHTML = team.id;
+
+            if (teams.length) {
+                for (let i = 1; i < teamsListDiv.children.length; i++) {
+                    teamsListDiv.children[i].remove();
+                }
+                for (const team of teams) {
+                    const item = UI.createListItem(team.id);
+                    teamsListDiv.appendChild(item);
+                }
+            }
         }
     }
 

--- a/packages/portal/frontend/src/app/custom/DefaultStudentView.ts
+++ b/packages/portal/frontend/src/app/custom/DefaultStudentView.ts
@@ -23,7 +23,6 @@ export class DefaultStudentView extends AbstractStudentView {
 
     private teams: TeamTransport[];
     private teamDeliverableIds: string[];
-    private teamDeliverableSelected: string;
 
     constructor(remoteUrl: string) {
         super();
@@ -107,10 +106,6 @@ export class DefaultStudentView extends AbstractStudentView {
         const that = this;
         const teamsListDiv = document.getElementById('studentPartnerDiv');
 
-        // make sure these are hidden
-        UI.hideSection('studentSelectPartnerDiv');
-        UI.hideSection('studentPartnerDiv');
-
         // configure team creation menus
         const button = document.querySelector('#studentSelectPartnerButton') as OnsButtonElement;
         button.onclick = function(evt: any) {
@@ -126,16 +121,18 @@ export class DefaultStudentView extends AbstractStudentView {
             });
         };
 
-        UI.showSection('studentSelectPartnerDiv');
-        // already on team
-        UI.showSection('studentPartnerDiv');
-
         const teamElement = document.getElementById('studentPartnerTeamName');
-        // const partnerElement = document.getElementById('studentPartnerTeammates');
 
         if (teams.length) {
-            for (let i = 1; i < teamsListDiv.children.length; i++) {
-                teamsListDiv.children[i].remove();
+            const studentNotOnTeamMsg = document.getElementById('studentNotOnTeamMsg');
+            if (studentNotOnTeamMsg) {
+                studentNotOnTeamMsg.remove();
+            }
+
+            const teamItems = teamsListDiv.querySelectorAll('ons-list-item');
+            // tslint:disable-next-line:prefer-for-of
+            for (let i = 0; i < teamItems.length; i++) {
+                teamItems[i].remove();
             }
             for (const team of teams) {
                 const item = UI.createListItem(team.id);
@@ -147,9 +144,10 @@ export class DefaultStudentView extends AbstractStudentView {
     private async formTeam(): Promise<TeamTransport> {
         Log.info("DefaultStudentView::formTeam() - start");
         const otherId = UI.getTextFieldValue('studentSelectPartnerText');
+        const delivMenu = document.getElementById('studentSelectDeliverable') as OnsSelectElement;
         const myGithubId = this.getStudent().githubId;
         const payload: TeamFormationTransport = {
-            delivId:   'project', // only one team in cs310 (and it is always called project)
+            delivId:   delivMenu.options[delivMenu.selectedIndex].value,
             githubIds: [myGithubId, otherId]
         };
         const url = this.remote + '/portal/team';
@@ -178,17 +176,15 @@ export class DefaultStudentView extends AbstractStudentView {
         }
     }
 
-    private editDelivSelection(val: any) {
-        this.teamDeliverableSelected = val;
-    }
-
     private async renderDeliverableSelectMenu(deliverableIds: string[]): Promise<void> {
         Log.info('rendering deliverable select menu');
-        const delivSelect = document.querySelector('#studentSelectDeliverable') as OnsSelectElement;
-        deliverableIds.forEach((id) => {
-            const opt = UI.createOption(id, id);
-            delivSelect.firstChild.appendChild(opt);
-        });
+        const delivSelect = document.getElementById('studentSelectDeliverable') as OnsSelectElement;
+        if (delivSelect.options.length === 0) {
+            deliverableIds.forEach((id) => {
+                const opt = UI.createOption(id, id);
+                delivSelect.firstChild.appendChild(opt);
+            });
+        }
         Log.info(this.teamDeliverableIds);
     }
 

--- a/packages/portal/frontend/src/app/util/UI.ts
+++ b/packages/portal/frontend/src/app/util/UI.ts
@@ -306,7 +306,7 @@ export class UI {
             classlistDialog.show();
         })
         .catch(function(err: Error) {
-            Log.error('UI::prompt(..) - ERROR: ' + err.message);
+            Log.error('UI::prompt(..) - ERROR: ' + err);
         });
     }
 

--- a/packages/portal/frontend/src/app/util/UI.ts
+++ b/packages/portal/frontend/src/app/util/UI.ts
@@ -102,6 +102,10 @@ export class UI {
         ons.notification.toast(opts);
     }
 
+    public static createOption(text: string, value: string): HTMLElement {
+        return ons.createElement('<option value=' + value + '>' + text + '</option>');
+    }
+
     public static createListItem(text: string, subtext?: string, tappable?: boolean): HTMLElement {
 
         let prefix = '<ons-list-item style="display: table;">';


### PR DESCRIPTION
From issues: https://github.com/ubccpsc/classy/issues/227 and https://github.com/ubccpsc/classy/issues/341.  

NOTE: As deliverable configuration data could include sensitive information in the grading rubric, custom field, or even a Github key in a clone address, we must create a custom list of deliverables where teams are allowed so that the student kind can access this information to create teams with. 

UI Requirements:
- List teams that student is on OR display message that student is not on any teams on
- List ONLY deliverables that student is allowed to form a team for on
- Adding ability to add more than 1 teammate to team on

Back-end Requirements:
- Send a list of Deliverables to the front-end via the ConfigTransport type.
