### PR TITLE
Feature/login refresh user kind

### DIFF
--- a/packages/portal/backend/src/server/common/AuthRoutes.ts
+++ b/packages/portal/backend/src/server/common/AuthRoutes.ts
@@ -284,7 +284,7 @@ export class AuthRoutes implements IREST {
             person = await cc.handleUnknownUser(username);
         } else {
             Log.trace("AuthRoutes::performAuthCallback(..) - /portal/authCallback - github username IS registered");
-            // updates user role on login. withdrawn students cannot login and therefore are not affected.
+            // forces update of user role on login.
             person.kind = null;
             await new PersonController().writePerson(person);
             Log.trace("AuthRoutes::performAuthCallback(..) - person kind reset for " + JSON.stringify(person));

--- a/packages/portal/backend/src/server/common/AuthRoutes.ts
+++ b/packages/portal/backend/src/server/common/AuthRoutes.ts
@@ -284,6 +284,10 @@ export class AuthRoutes implements IREST {
             person = await cc.handleUnknownUser(username);
         } else {
             Log.trace("AuthRoutes::performAuthCallback(..) - /portal/authCallback - github username IS registered");
+            // updates user role on login. withdrawn students cannot login and therefore are not affected.
+            person.kind = null;
+            await new PersonController().writePerson(person);
+            Log.trace("AuthRoutes::performAuthCallback(..) - person kind reset for " + JSON.stringify(person));
         }
 
         // now we either have the person in the course or there will never be one
@@ -320,13 +324,6 @@ export class AuthRoutes implements IREST {
             };
 
             await DatabaseController.getInstance().writeAuth(auth);
-
-            // updates user role on login. withdrawn students cannot login and therefore are not affected.
-            person.kind = null;
-            await new PersonController().writePerson(person);
-
-            Log.trace("AuthRoutes::performAuthCallback(..) - person kind reset on login: " + JSON.stringify(person));
-
             Log.trace("AuthRoutes::performAuthCallback(..) - preparing redirect for: " + JSON.stringify(person));
 
             Log.trace("AuthRoutes::performAuthCallback(..) - /authCallback - redirect hostname: " + feUrl + "; fePort: " + fePort);


### PR DESCRIPTION
Moves the logic to refresh a user kind into the authentication procedure instead of after logging out. This ensures that a user is without a kind role for only a split second instead of the time-range between logging out and logging in again.

This fixes problems with queries that instructors may make on student roles while the student is logged out.